### PR TITLE
feat: Update SelectableResidueIcons component and replace placeholder…

### DIFF
--- a/RecoletaNative/components/custom/WasteManagementInterface/SelectableResidueIcons/SelectableResidueIcons.tsx
+++ b/RecoletaNative/components/custom/WasteManagementInterface/SelectableResidueIcons/SelectableResidueIcons.tsx
@@ -23,24 +23,25 @@ const SelectableResidueIcons: React.FC<SelectableResidueIconsProps> = ({
               key={card.id}
               className={`items-center my-2 border ${
                 Platform.OS === "android" ? "w-[165px]" : "w-[150px]"
-              } h-fit p-2 rounded-lg 
-                  ${isSelected ? "border-blue-500" : "border-zinc-300"}`}
+              } 
+              ${isSelected ? "border-blue-500" : "border-zinc-300"}`}
             >
               <Image
                 source={{ uri: card.image }}
                 style={{
-                  height: 250,
-                  width: 250,
+                  width: "100%",
+                  aspectRatio: 1,
+                  resizeMode: "contain",
                 }}
-                className={` ${
-                  Platform.OS === "android" ? "h-[145]" : "w-[100px] h-[125px]"
-                }  `}
+                className="h-24"
               />
-              <Text
-                className={`${isSelected ? "font-bold text-blue-500" : ""}`}
-              >
-                {card.name}
-              </Text>
+              <View className="mt-5">
+                <Text
+                  className={`${isSelected ? "font-bold text-blue-500" : ""}`}
+                >
+                  {card.name}
+                </Text>
+              </View>
             </Card>
           );
         })}

--- a/RecoletaNative/components/custom/WasteManagementInterface/utils/enum.ts
+++ b/RecoletaNative/components/custom/WasteManagementInterface/utils/enum.ts
@@ -4,38 +4,41 @@ const RESIDUE_CARDS = [
   {
     id: "1",
     name: "Papel",
-    image: "https://via.placeholder.com/150",
+    image: "https://i.ibb.co/k25g5Lpv/paper.png",
     alt: "Papel",
   },
   {
     id: "2",
     name: "Plástico",
-    image: "https://via.placeholder.com/150",
+    image: "https://i.ibb.co/qMX0rPkM/plastic.png",
     alt: "Plástico",
   },
   {
     id: "3",
     name: "Vidro",
-    image: "https://via.placeholder.com/150",
+    image: "https://i.ibb.co/GfM37wgP/glass.png",
     alt: "Vidro",
   },
   {
     id: "4",
     name: "Eletrônico",
-    image: "https://via.placeholder.com/150",
+    image: "https://i.ibb.co/tTJGbF1M/electronic.png",
     alt: "Vidro",
   },
   {
     id: "5",
     name: "Orgânico",
-    image: "https://via.placeholder.com/150",
+    image: "https://i.ibb.co/tj5g2mm/organic.png",
     alt: "Orgânico",
   },
   {
     id: "6",
     name: "Metal",
-    image: "https://via.placeholder.com/150",
+    image: "https://i.ibb.co/nN0kbw0J/metal.png",
     alt: "Metal",
   },
 ];
 export { RESIDUE_CONDITIONS, PACKAGE_OPTIONS, RESIDUE_CARDS };
+
+/* https://i.ibb.co/kgrQYvff/can.png
+https://i.ibb.co/spzS5tkw/bottle.png */


### PR DESCRIPTION
This pull request includes changes to improve the visual presentation of residue cards in the `WasteManagementInterface` component by updating the styling and replacing placeholder images with specific residue images.

Styling improvements:

* [`RecoletaNative/components/custom/WasteManagementInterface/SelectableResidueIcons/SelectableResidueIcons.tsx`](diffhunk://#diff-6d9975e9745c4905ff4cd15cd0aa2359206dfa43467de543f9938a9f76c9f2b2L26-R44): Adjusted the image styling to use a responsive width and aspect ratio, and added a margin to the text container for better spacing.

Image updates:

* [`RecoletaNative/components/custom/WasteManagementInterface/utils/enum.ts`](diffhunk://#diff-455f068641a5550e62153fb98439178ea00fb61ed58054c39a68f1dc86cba4d8L7-R44): Replaced placeholder images with specific images for each residue type to enhance user experience.