### PR TITLE
[SCRUM-134]: FE Implementar registered adressess component

### DIFF
--- a/components/custom/AddressInterface/AddNewAddress/AddNewAddress.tsx
+++ b/components/custom/AddressInterface/AddNewAddress/AddNewAddress.tsx
@@ -2,27 +2,7 @@ import React, { FC } from "react";
 import { View, StyleSheet } from "react-native";
 import { AddNewAddressForm } from "./components/AddNewAddressForm";
 import { AddNewAddressViaGPS } from "./components/AddNewAddressViaGPS";
-
-export interface AddNewAddressProps {
-  latitude?: number | string;
-  longitude?: number | string;
-  postalCode: string;
-  number: string;
-  street: string;
-  complement: string;
-  neighborhood: string;
-  city: string;
-  state: string;
-  setLatitude?: (value: number) => void;
-  setLongitude?: (value: number) => void;
-  setPostalCode: (value: string) => void;
-  setNumber: (value: string) => void;
-  setStreet: (value: string) => void;
-  setComplement: (value: string) => void;
-  setNeighborhood: (value: string) => void;
-  setCity: (value: string) => void;
-  setState: (value: string) => void;
-}
+import { AddNewAddressProps } from "../types";
 
 const AddNewAddress: FC<AddNewAddressProps> = ({
   latitude,

--- a/components/custom/AddressInterface/AddNewAddress/components/AddNewAddressForm/AddNewAddressForm.tsx
+++ b/components/custom/AddressInterface/AddNewAddress/components/AddNewAddressForm/AddNewAddressForm.tsx
@@ -1,22 +1,6 @@
 import React, { FC } from "react";
 import { View, Text, TextInput, StyleSheet } from "react-native";
-
-interface AddNewAddressFormProps {
-  postalCode: string;
-  number: string;
-  street: string;
-  complement: string;
-  neighborhood: string;
-  city: string;
-  state: string;
-  setPostalCode: (value: string) => void;
-  setNumber: (value: string) => void;
-  setStreet: (value: string) => void;
-  setComplement: (value: string) => void;
-  setNeighborhood: (value: string) => void;
-  setCity: (value: string) => void;
-  setState: (value: string) => void;
-}
+import { AddNewAddressFormProps } from "../../../types";
 
 const AddNewAddressForm: FC<AddNewAddressFormProps> = ({
   postalCode,

--- a/components/custom/AddressInterface/AddressInterface.tsx
+++ b/components/custom/AddressInterface/AddressInterface.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { View } from "react-native";
 import { useAddress } from "@/hooks/useAddress";
 import { Card } from "@/components/ui/card";
@@ -8,8 +8,18 @@ import { InterfaceSwitch } from "../InterfaceSwitch";
 import AddNewAddress from "./AddNewAddress/AddNewAddress";
 import { ChosenResidueCard } from "./AddNewAddress/ChosenResidueCard";
 import { RegisteredAddresses } from "./RegisteredAddresses";
+import Constants from "expo-constants";
+import { Address } from "./types";
+import axios from "axios";
+import { useAuth } from "@/context/AuthContext";
+import { useCollectFlow } from "@/context/CollectFlowContext";
 
 const AddressInterface: React.FC = ({}) => {
+  const [hasRegisteredAddresses, setHasRegisteredAddresses] = useState(false);
+  const [toggleDefault, setToggleDefault] = useState(false);
+  const { authState } = useAuth();
+  const { API_URL } = Constants.expoConfig?.extra || {};
+  const { setCollectFlowData, resetAddressData } = useCollectFlow();
   const {
     latitude,
     longitude,
@@ -31,6 +41,37 @@ const AddressInterface: React.FC = ({}) => {
     setPostalCode,
   } = useAddress();
 
+  useEffect(() => {
+    const checkUserAddresses = async () => {
+      try {
+        const res = await axios.get<Address[]>(`${API_URL}/address/user`, {
+          headers: {
+            Authorization: `Bearer ${authState?.token}`,
+          },
+        });
+        if (res.data.length > 0) {
+          setHasRegisteredAddresses(!hasRegisteredAddresses);
+          setToggleDefault(hasRegisteredAddresses); // start on left (registered addresses)
+        } else {
+          setHasRegisteredAddresses(hasRegisteredAddresses);
+          setToggleDefault(!hasRegisteredAddresses); // no addresses, start on right (add new)
+        }
+      } catch (error) {
+        console.error("Erro ao verificar endereços:", error);
+      }
+    };
+
+    checkUserAddresses();
+  }, []);
+
+  const handleSwitchChange = (isToggled: boolean) => {
+    if (isToggled) {
+      // switched to "Novo Endereço"
+      setCollectFlowData({ previousRegisteredAddressSelectedId: null });
+      resetAddressData();
+    }
+  };
+
   return (
     <Card className="border border-zinc-300">
       <View className="mb-6">
@@ -50,7 +91,8 @@ const AddressInterface: React.FC = ({}) => {
       <InterfaceSwitch
         rightLabel="Novo Endereço"
         leftLabel="Endereços Cadastrados"
-        defaultValue={true}
+        defaultValue={toggleDefault}
+        onToggleChange={handleSwitchChange}
         leftComponent={<RegisteredAddresses />}
         rightComponent={
           <AddNewAddress

--- a/components/custom/AddressInterface/AddressInterface.tsx
+++ b/components/custom/AddressInterface/AddressInterface.tsx
@@ -7,11 +7,9 @@ import { Text } from "@/components/ui/text";
 import { InterfaceSwitch } from "../InterfaceSwitch";
 import AddNewAddress from "./AddNewAddress/AddNewAddress";
 import { ChosenResidueCard } from "./AddNewAddress/ChosenResidueCard";
-import RegisteredAddresses from "./RegisteredAddresses/RegisteredAdresses";
+import { RegisteredAddresses } from "./RegisteredAddresses";
 
-interface AddressInterfaceProps {}
-
-const AddressInterface: React.FC<AddressInterfaceProps> = ({}) => {
+const AddressInterface: React.FC = ({}) => {
   const {
     latitude,
     longitude,

--- a/components/custom/AddressInterface/RegisteredAddresses/RegisteredAddressCard/RegisterdAddressCard.tsx
+++ b/components/custom/AddressInterface/RegisteredAddresses/RegisteredAddressCard/RegisterdAddressCard.tsx
@@ -1,14 +1,25 @@
 import React, { FC } from "react";
-import { View, Text } from "react-native";
+import { Text, Pressable } from "react-native";
 import { Address } from "../../types";
 
 interface RegisteredAddressCardProps {
   item: Address;
+  onSelect: (id: string) => void;
+  selected: boolean;
 }
 
-const RegisteredAddressCard: FC<RegisteredAddressCardProps> = ({ item }) => {
+const RegisteredAddressCard: FC<RegisteredAddressCardProps> = ({
+  item,
+  onSelect,
+  selected,
+}) => {
   return (
-    <View className="mb-3 p-4 bg-white rounded-xl shadow ">
+    <Pressable
+      onPress={() => onSelect(item._id)}
+      className={`mb-3 p-4 rounded-xl shadow ${
+        selected ? "bg-green-100 border border-green-500" : "bg-white"
+      }`}
+    >
       <Text className="font-medium">
         {item.street}, {item.number}
       </Text>
@@ -16,7 +27,8 @@ const RegisteredAddressCard: FC<RegisteredAddressCardProps> = ({ item }) => {
         {item.neighborhood}, {item.city} - {item.state}
       </Text>
       <Text className="text-xs text-gray-400">CEP: {item.postalCode}</Text>
-    </View>
+    </Pressable>
   );
 };
+
 export default RegisteredAddressCard;

--- a/components/custom/AddressInterface/RegisteredAddresses/RegisteredAddressCard/RegisterdAddressCard.tsx
+++ b/components/custom/AddressInterface/RegisteredAddresses/RegisteredAddressCard/RegisterdAddressCard.tsx
@@ -1,0 +1,22 @@
+import React, { FC } from "react";
+import { View, Text } from "react-native";
+import { Address } from "../../types";
+
+interface RegisteredAddressCardProps {
+  item: Address;
+}
+
+const RegisteredAddressCard: FC<RegisteredAddressCardProps> = ({ item }) => {
+  return (
+    <View className="mb-3 p-4 bg-white rounded-xl shadow ">
+      <Text className="font-medium">
+        {item.street}, {item.number}
+      </Text>
+      <Text className="text-sm text-gray-600">
+        {item.neighborhood}, {item.city} - {item.state}
+      </Text>
+      <Text className="text-xs text-gray-400">CEP: {item.postalCode}</Text>
+    </View>
+  );
+};
+export default RegisteredAddressCard;

--- a/components/custom/AddressInterface/RegisteredAddresses/RegisteredAddressCard/index.ts
+++ b/components/custom/AddressInterface/RegisteredAddresses/RegisteredAddressCard/index.ts
@@ -1,0 +1,1 @@
+export { default as RegisteredAddressCard } from "./RegisterdAddressCard";

--- a/components/custom/AddressInterface/RegisteredAddresses/RegisteredAdresses.tsx
+++ b/components/custom/AddressInterface/RegisteredAddresses/RegisteredAdresses.tsx
@@ -1,15 +1,64 @@
-import React from "react";
-import { View, Text } from "react-native";
+import React, { useEffect, useState } from "react";
+import { View, Text, ActivityIndicator, ScrollView } from "react-native";
+import axios from "axios";
+import { useAuth } from "@/context/AuthContext";
+import Constants from "expo-constants";
+import { Address } from "../types";
+import RegisteredAddressCard from "./RegisteredAddressCard/RegisterdAddressCard";
+
 const RegisteredAddresses = () => {
+  const { authState } = useAuth();
+  const [addresses, setAddresses] = useState<Address[]>([]);
+  const [loading, setLoading] = useState<boolean>(true);
+  const [error, setError] = useState<string | null>(null);
+  const { API_URL } = Constants.expoConfig?.extra || {};
+
+  useEffect(() => {
+    const fetchAddresses = async () => {
+      try {
+        setLoading(true);
+        const res = await axios.get<Address[]>(`${API_URL}/address/user`, {
+          headers: {
+            Authorization: `Bearer ${authState?.token}`,
+          },
+        });
+        setAddresses(res.data);
+      } catch (err: any) {
+        console.error(
+          "Erro ao buscar endereços:",
+          err?.response?.data || err.message
+        );
+        setError("Erro ao carregar endereços.");
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchAddresses();
+  }, []);
+
   return (
-    <View className=" h-full p-4 ">
+    <ScrollView contentContainerStyle={{ padding: 6 }}>
       <Text className="text-lg font-bold mb-2">Endereços Cadastrados</Text>
-      <Text className="text-sm text-gray-600">
+      <Text className="text-sm text-gray-600 mb-4">
         Aqui estão os endereços que você cadastrou.
       </Text>
-      {/* Aqui você pode adicionar a lógica para listar os endereços cadastrados */}
-      {/* e permitir que o usuário selecione um deles */}
-    </View>
+
+      {error && <Text className="text-red-500 mb-4">{error}</Text>}
+
+      {loading ? (
+        <View className="justify-center items-center my-6">
+          <ActivityIndicator size="large" />
+        </View>
+      ) : addresses.length === 0 ? (
+        <Text className="text-gray-500">Nenhum endereço cadastrado ainda.</Text>
+      ) : (
+        addresses.map((item) => (
+          <RegisteredAddressCard item={item} key={item._id} />
+        ))
+      )}
+    </ScrollView>
   );
 };
+
 export default RegisteredAddresses;

--- a/components/custom/AddressInterface/RegisteredAddresses/RegisteredAdresses.tsx
+++ b/components/custom/AddressInterface/RegisteredAddresses/RegisteredAdresses.tsx
@@ -5,6 +5,7 @@ import { useAuth } from "@/context/AuthContext";
 import Constants from "expo-constants";
 import { Address } from "../types";
 import RegisteredAddressCard from "./RegisteredAddressCard/RegisterdAddressCard";
+import { useCollectFlow } from "@/context/CollectFlowContext";
 
 const RegisteredAddresses = () => {
   const { authState } = useAuth();
@@ -12,7 +13,14 @@ const RegisteredAddresses = () => {
   const [loading, setLoading] = useState<boolean>(true);
   const [error, setError] = useState<string | null>(null);
   const { API_URL } = Constants.expoConfig?.extra || {};
+  const { previousRegisteredAddressSelectedId, setCollectFlowData } =
+    useCollectFlow();
 
+  const handleSelectAddress = (id: string) => {
+    setCollectFlowData({ previousRegisteredAddressSelectedId: id });
+  };
+
+  console.log("Selected Address ID:", previousRegisteredAddressSelectedId);
   useEffect(() => {
     const fetchAddresses = async () => {
       try {
@@ -54,7 +62,12 @@ const RegisteredAddresses = () => {
         <Text className="text-gray-500">Nenhum endereço cadastrado ainda.</Text>
       ) : (
         addresses.map((item) => (
-          <RegisteredAddressCard item={item} key={item._id} />
+          <RegisteredAddressCard
+            item={item}
+            key={item._id}
+            onSelect={handleSelectAddress}
+            selected={previousRegisteredAddressSelectedId === item._id}
+          />
         ))
       )}
     </ScrollView>

--- a/components/custom/AddressInterface/RegisteredAddresses/index.ts
+++ b/components/custom/AddressInterface/RegisteredAddresses/index.ts
@@ -1,0 +1,1 @@
+export { default as RegisteredAddresses } from "./RegisteredAdresses";

--- a/components/custom/AddressInterface/types/index.ts
+++ b/components/custom/AddressInterface/types/index.ts
@@ -1,0 +1,54 @@
+interface AddNewAddressProps {
+  latitude?: number | string;
+  longitude?: number | string;
+  postalCode: string;
+  number: string;
+  street: string;
+  complement: string;
+  neighborhood: string;
+  city: string;
+  state: string;
+  setLatitude?: (value: number) => void;
+  setLongitude?: (value: number) => void;
+  setPostalCode: (value: string) => void;
+  setNumber: (value: string) => void;
+  setStreet: (value: string) => void;
+  setComplement: (value: string) => void;
+  setNeighborhood: (value: string) => void;
+  setCity: (value: string) => void;
+  setState: (value: string) => void;
+}
+
+interface AddNewAddressFormProps {
+  postalCode: string;
+  number: string;
+  street: string;
+  complement: string;
+  neighborhood: string;
+  city: string;
+  state: string;
+  setPostalCode: (value: string) => void;
+  setNumber: (value: string) => void;
+  setStreet: (value: string) => void;
+  setComplement: (value: string) => void;
+  setNeighborhood: (value: string) => void;
+  setCity: (value: string) => void;
+  setState: (value: string) => void;
+}
+
+interface Address {
+  _id: string;
+  postalCode: string;
+  number: string;
+  street: string;
+  complement: string;
+  neighborhood: string;
+  city: string;
+  state: string;
+  latitude?: number;
+  longitude?: number;
+  createdAt?: string;
+  updatedAt?: string;
+}
+
+export { AddNewAddressProps, AddNewAddressFormProps, Address };

--- a/components/custom/CreateCollectModal/CreateCollectModal.tsx
+++ b/components/custom/CreateCollectModal/CreateCollectModal.tsx
@@ -17,6 +17,7 @@ import { AddressInterface } from "../AddressInterface";
 import { useResidue } from "@/hooks/useResidue";
 import { useAddress } from "@/hooks/useAddress";
 import { useCollectEvent } from "@/hooks/useCollectHookEvent";
+import { useCollectFlow } from "@/context/CollectFlowContext";
 
 interface ResidueModalFlowProps {
   visible: boolean;
@@ -31,7 +32,7 @@ const ResidueModalFlow: React.FC<ResidueModalFlowProps> = ({
   const { isResidueValid, payloadResidue } = useResidue();
   const { isAddressValid } = useAddress();
   const { handleSubmit, loading } = useCollectEvent();
-
+  const { previousRegisteredAddressSelectedId } = useCollectFlow();
   const handleClose = () => {
     setStep(1);
     onClose();
@@ -44,6 +45,8 @@ const ResidueModalFlow: React.FC<ResidueModalFlowProps> = ({
   const handleBack = () => {
     if (step === 2) setStep(1);
   };
+
+  const canSubmit = isAddressValid || !!previousRegisteredAddressSelectedId;
 
   console.log("Residue Payload", payloadResidue);
 
@@ -120,9 +123,9 @@ const ResidueModalFlow: React.FC<ResidueModalFlowProps> = ({
                       if (success) handleClose();
                     }}
                     className={`px-4 py-2 rounded-lg ${
-                      isAddressValid ? "bg-blue-600" : "bg-gray-300"
+                      canSubmit ? "bg-blue-600" : "bg-gray-300"
                     }`}
-                    disabled={!isAddressValid || loading}
+                    disabled={!canSubmit || loading}
                   >
                     <Text className="text-white">
                       {loading ? "Salvando..." : "Confirmar"}

--- a/components/custom/InterfaceSwitch/InterfaceSwitch.tsx
+++ b/components/custom/InterfaceSwitch/InterfaceSwitch.tsx
@@ -7,6 +7,7 @@ interface InterfaceSwitchProps {
   rightComponent: ReactNode;
   leftComponent: ReactNode;
   defaultValue?: boolean;
+  onToggleChange?: (value: boolean) => void;
 }
 
 const InterfaceSwitch: React.FC<InterfaceSwitchProps> = ({
@@ -15,8 +16,14 @@ const InterfaceSwitch: React.FC<InterfaceSwitchProps> = ({
   rightComponent,
   leftComponent,
   defaultValue = false, // Default state
+  onToggleChange,
 }) => {
   const [isToggled, setIsToggled] = useState(defaultValue);
+
+  const handleToggle = (value: boolean) => {
+    setIsToggled(value);
+    onToggleChange?.(value);
+  };
 
   return (
     <>
@@ -25,7 +32,7 @@ const InterfaceSwitch: React.FC<InterfaceSwitchProps> = ({
         {/* Left Button (Inactive/Active) */}
         <Pressable
           style={[styles.button, !isToggled && styles.activeButton]}
-          onPress={() => setIsToggled(false)}
+          onPress={() => handleToggle(false)}
         >
           <Text style={[styles.buttonText, !isToggled && styles.activeText]}>
             {leftLabel}
@@ -35,7 +42,7 @@ const InterfaceSwitch: React.FC<InterfaceSwitchProps> = ({
         {/* Right Button (Active/Inactive) */}
         <Pressable
           style={[styles.button, isToggled && styles.activeButton]}
-          onPress={() => setIsToggled(true)}
+          onPress={() => handleToggle(true)}
         >
           <Text style={[styles.buttonText, isToggled && styles.activeText]}>
             {rightLabel}

--- a/context/CollectFlowContext.tsx
+++ b/context/CollectFlowContext.tsx
@@ -22,8 +22,10 @@ interface CollectFlowState {
   longitude?: number | string;
 
   // Methods
+  previousRegisteredAddressSelectedId: string | null;
   setCollectFlowData: (data: Partial<CollectFlowState>) => void;
   resetCollectFlow: () => void;
+  resetAddressData: () => void;
   getResiduePayload: () => {
     name: string;
     weight: string;
@@ -43,7 +45,10 @@ export const CollectFlowProvider: React.FC<{ children: React.ReactNode }> = ({
   const [state, setState] = useState<
     Omit<
       CollectFlowState,
-      "setCollectFlowData" | "resetCollectFlow" | "getResiduePayload"
+      | "setCollectFlowData"
+      | "resetCollectFlow"
+      | "getResiduePayload"
+      | "resetAddressData"
     >
   >({
     selectedResidue: null,
@@ -53,6 +58,7 @@ export const CollectFlowProvider: React.FC<{ children: React.ReactNode }> = ({
     selectedDate: null,
     selectedHour: null,
     photo: null,
+    previousRegisteredAddressSelectedId: null,
 
     city: "",
     neighborhood: "",
@@ -76,6 +82,7 @@ export const CollectFlowProvider: React.FC<{ children: React.ReactNode }> = ({
       selectedDate: null,
       selectedHour: null,
       photo: null,
+      previousRegisteredAddressSelectedId: null,
 
       city: "",
       neighborhood: "",
@@ -85,6 +92,22 @@ export const CollectFlowProvider: React.FC<{ children: React.ReactNode }> = ({
       complement: "",
       postalCode: "",
     });
+  };
+  // Resets only address-related fields (and clears a previously selected address)
+  const resetAddressData = () => {
+    setState((prev) => ({
+      ...prev,
+      previousRegisteredAddressSelectedId: null,
+      city: "",
+      neighborhood: "",
+      state: "",
+      street: "",
+      number: "",
+      complement: "",
+      postalCode: "",
+      latitude: undefined,
+      longitude: undefined,
+    }));
   };
 
   const getResiduePayload = () => {
@@ -107,7 +130,8 @@ export const CollectFlowProvider: React.FC<{ children: React.ReactNode }> = ({
         ...state,
         setCollectFlowData,
         resetCollectFlow,
-        getResiduePayload, // 👈 exposed here
+        getResiduePayload,
+        resetAddressData, // 👈 exposed here
       }}
     >
       {children}


### PR DESCRIPTION
[SCRUM-134](https://fatec-team-ext4gbza.atlassian.net/browse/SCRUM-134) ✔️ 

## Description

Build:
[Download](https://expo.dev/accounts/wakenedo/projects/RecoletaNative/builds/b2634125-1c6e-40ff-b68b-40ee80fe58bb)

Nesse PR estamos implementando o componente `RegisterdAddresses`  com esse componente estamos recebendo os endereços já registrados pelo usuário para facilitar o processo de criação de eventos para usuários que já cadastraram endereços previamente. 

Alteramos o comportamento do componente `SwitchInterface` para controlarmos melhor os resultados das tabs. Nesse caso verificamos se o usuário tem endereços cadastrados e caso tenha , ele será sempre direcionado duranto o segundo passo da modal a interface de `RegisteredAddresses`

Alteramos o `CollectFlowContext` para lidar com as açoes do usuário durante o segundo passo do registro do evento, caso o usuário altere do `RegisteredAddresses` para o `AddNewAddress` resetamos as informações do Address através do método `resetAddressData` 

Alteramos o `useCollectHookEvent` para lidar com os casos dos Address previamente registrados e como se integram com o fluxo, dessa maneirao usuário pode selecionar o endereço previamente registrado com um simples toque e prosseguir para a criação do evento. 

### Screenshots 
![Capturar2](https://github.com/user-attachments/assets/8f264261-56e7-438c-bfe9-a39021a2122b)

![image](https://github.com/user-attachments/assets/affa1785-5612-4994-8f64-dd8e4b0e6c83)


[SCRUM-134]: https://fatec-team-ext4gbza.atlassian.net/browse/SCRUM-134?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ