### PR TITLE
[FIX]: Splashscreen behavior & Improved UX

### DIFF
--- a/components/AnimatedSplashScreen.tsx
+++ b/components/AnimatedSplashScreen.tsx
@@ -13,25 +13,14 @@ const AnimatedSplashScreen = ({ onFinish }: { onFinish: () => void }) => {
   useEffect(() => {
     const runSplash = async () => {
       try {
-        const hasSeenSplash = await AsyncStorage.getItem("hasSeenSplash");
+        animationRef.current?.play(); // Start the Lottie animation
 
-        const devForceSplash = __DEV__ && true;
+        await waitForAnimation(3000); // Wait 3 seconds (or match your animation time)
 
-        if (hasSeenSplash && !devForceSplash) {
-          await hideSplashAndFinish();
-          return;
-        }
-
-        animationRef.current?.play();
-
-        await waitForAnimation(3000); // Adjust to match your Lottie length
-
-        await AsyncStorage.setItem("hasSeenSplash", "true");
-
-        fadeOutSplash();
+        fadeOutSplash(); // Fade out splash and reveal app
       } catch (error) {
         console.error("[Splash] Error during splash:", error);
-        await hideSplashAndFinish();
+        await hideSplashAndFinish(); // Fallback if anything goes wrong
       }
     };
 

--- a/components/custom/AddressInterface/AddressInterface.tsx
+++ b/components/custom/AddressInterface/AddressInterface.tsx
@@ -65,8 +65,9 @@ const AddressInterface: React.FC = ({}) => {
   }, []);
 
   const handleSwitchChange = (isToggled: boolean) => {
+    setToggleDefault(isToggled); // Update state based on user action
+
     if (isToggled) {
-      // switched to "Novo Endereço"
       setCollectFlowData({ previousRegisteredAddressSelectedId: null });
       resetAddressData();
     }
@@ -88,35 +89,59 @@ const AddressInterface: React.FC = ({}) => {
         <ChosenResidueCard />
       </View>
 
-      <InterfaceSwitch
-        rightLabel="Novo Endereço"
-        leftLabel="Endereços Cadastrados"
-        defaultValue={toggleDefault}
-        onToggleChange={handleSwitchChange}
-        leftComponent={<RegisteredAddresses />}
-        rightComponent={
-          <AddNewAddress
-            latitude={latitude}
-            longitude={longitude}
-            neighborhood={neighborhood}
-            state={state}
-            street={street}
-            number={number}
-            complement={complement}
-            city={city}
-            postalCode={postalCode}
-            setLatitude={setLatitude}
-            setLongitude={setLongitude}
-            setNeighborhood={setNeighborhood}
-            setState={setState}
-            setStreet={setStreet}
-            setNumber={setNumber}
-            setComplement={setComplement}
-            setCity={setCity}
-            setPostalCode={setPostalCode}
-          />
-        }
-      />
+      {hasRegisteredAddresses && (
+        <InterfaceSwitch
+          rightLabel="Novo Endereço"
+          leftLabel="Endereços Cadastrados"
+          value={toggleDefault}
+          onToggleChange={handleSwitchChange}
+          leftComponent={<RegisteredAddresses />}
+          rightComponent={
+            <AddNewAddress
+              latitude={latitude}
+              longitude={longitude}
+              neighborhood={neighborhood}
+              state={state}
+              street={street}
+              number={number}
+              complement={complement}
+              city={city}
+              postalCode={postalCode}
+              setLatitude={setLatitude}
+              setLongitude={setLongitude}
+              setNeighborhood={setNeighborhood}
+              setState={setState}
+              setStreet={setStreet}
+              setNumber={setNumber}
+              setComplement={setComplement}
+              setCity={setCity}
+              setPostalCode={setPostalCode}
+            />
+          }
+        />
+      )}
+      {!hasRegisteredAddresses && (
+        <AddNewAddress
+          latitude={latitude}
+          longitude={longitude}
+          neighborhood={neighborhood}
+          state={state}
+          street={street}
+          number={number}
+          complement={complement}
+          city={city}
+          postalCode={postalCode}
+          setLatitude={setLatitude}
+          setLongitude={setLongitude}
+          setNeighborhood={setNeighborhood}
+          setState={setState}
+          setStreet={setStreet}
+          setNumber={setNumber}
+          setComplement={setComplement}
+          setCity={setCity}
+          setPostalCode={setPostalCode}
+        />
+      )}
     </Card>
   );
 };

--- a/components/custom/AuthInterface/DynamicForm/components/RegisterUser/components/RegisterUserTypePicker/RegisterUserTypePicker.tsx
+++ b/components/custom/AuthInterface/DynamicForm/components/RegisterUser/components/RegisterUserTypePicker/RegisterUserTypePicker.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import { View, Text, StyleSheet, TouchableOpacity } from "react-native";
 import { ChevronDown } from "lucide-react-native";
-import { Picker } from "@react-native-picker/picker";
 import { UserTypePickerProps } from "@/components/custom/AuthInterface/types/AuthInterfaceTypes";
 
 const RegisterUserTypePicker = ({
@@ -10,11 +9,21 @@ const RegisterUserTypePicker = ({
   showUserTypePicker,
   isLoading,
 }: UserTypePickerProps) => {
+  const options = [
+    { label: "Gerador de Resíduos", value: "PRODUCES_WASTE" },
+    { label: "Coletor de Resíduos", value: "COLLECTS_WASTE" },
+  ];
+
+  const handleSelect = (value: string) => {
+    field.onChange(value);
+    setShowUserTypePicker(false);
+  };
+
   return (
     <View>
       <TouchableOpacity
         style={styles.pickerTrigger}
-        onPress={() => setShowUserTypePicker(true)}
+        onPress={() => setShowUserTypePicker(!showUserTypePicker)}
         disabled={isLoading}
         accessibilityLabel="Selecione o tipo de usuário"
       >
@@ -31,23 +40,16 @@ const RegisterUserTypePicker = ({
       </TouchableOpacity>
 
       {showUserTypePicker && (
-        <View style={styles.pickerContainer}>
-          <Picker
-            selectedValue={field.value}
-            onValueChange={(itemValue) => {
-              field.onChange(itemValue);
-              setShowUserTypePicker(false);
-            }}
-            itemStyle={{
-              color: "black",
-              height: 120,
-              fontSize: 16,
-            }}
-          >
-            <Picker.Item label="Selecione o tipo" value="" />
-            <Picker.Item label="Gerador de Resíduos" value="PRODUCES_WASTE" />
-            <Picker.Item label="Coletor de Resíduos" value="COLLECTS_WASTE" />
-          </Picker>
+        <View style={styles.dropdown}>
+          {options.map((option) => (
+            <TouchableOpacity
+              key={option.value}
+              style={styles.dropdownItem}
+              onPress={() => handleSelect(option.value)}
+            >
+              <Text style={styles.dropdownItemText}>{option.label}</Text>
+            </TouchableOpacity>
+          ))}
         </View>
       )}
     </View>
@@ -56,6 +58,7 @@ const RegisterUserTypePicker = ({
 
 const styles = StyleSheet.create({
   pickerTrigger: {
+    elevation: 0.5,
     flexDirection: "row",
     justifyContent: "space-between",
     alignItems: "center",
@@ -70,12 +73,23 @@ const styles = StyleSheet.create({
   pickerValue: {
     color: "#000000",
   },
-  pickerContainer: {
-    backgroundColor: "white",
-    borderRadius: 8,
-    marginTop: 4,
-    borderWidth: 1,
-    borderColor: "#E5E7EB",
+  dropdown: {
+    position: "relative",
+    marginTop: -6,
+    backgroundColor: "#F3F4F6",
+    borderBottomLeftRadius: 8,
+    borderBottomRightRadius: 8,
+    overflow: "hidden",
+    // Elevation for Android
+    elevation: 0.5,
+  },
+  dropdownItem: {
+    paddingVertical: 12,
+    paddingHorizontal: 16,
+  },
+  dropdownItemText: {
+    fontSize: 16,
+    color: "#000",
   },
 });
 

--- a/components/custom/InterfaceSwitch/InterfaceSwitch.tsx
+++ b/components/custom/InterfaceSwitch/InterfaceSwitch.tsx
@@ -1,4 +1,4 @@
-import React, { useState, ReactNode } from "react";
+import React, { ReactNode } from "react";
 import { Pressable, View, Text, StyleSheet } from "react-native";
 
 interface InterfaceSwitchProps {
@@ -6,7 +6,7 @@ interface InterfaceSwitchProps {
   leftLabel: string;
   rightComponent: ReactNode;
   leftComponent: ReactNode;
-  defaultValue?: boolean;
+  value: boolean; // Controlled value
   onToggleChange?: (value: boolean) => void;
 }
 
@@ -15,43 +15,39 @@ const InterfaceSwitch: React.FC<InterfaceSwitchProps> = ({
   leftLabel,
   rightComponent,
   leftComponent,
-  defaultValue = false, // Default state
+  value,
   onToggleChange,
 }) => {
-  const [isToggled, setIsToggled] = useState(defaultValue);
-
-  const handleToggle = (value: boolean) => {
-    setIsToggled(value);
-    onToggleChange?.(value);
+  const handleToggle = (newValue: boolean) => {
+    if (onToggleChange) {
+      onToggleChange(newValue);
+    }
   };
 
   return (
     <>
       {/* Custom Toggle Buttons */}
       <View style={styles.switchContainer}>
-        {/* Left Button (Inactive/Active) */}
         <Pressable
-          style={[styles.button, !isToggled && styles.activeButton]}
+          style={[styles.button, !value && styles.activeButton]}
           onPress={() => handleToggle(false)}
         >
-          <Text style={[styles.buttonText, !isToggled && styles.activeText]}>
+          <Text style={[styles.buttonText, !value && styles.activeText]}>
             {leftLabel}
           </Text>
         </Pressable>
 
-        {/* Right Button (Active/Inactive) */}
         <Pressable
-          style={[styles.button, isToggled && styles.activeButton]}
+          style={[styles.button, value && styles.activeButton]}
           onPress={() => handleToggle(true)}
         >
-          <Text style={[styles.buttonText, isToggled && styles.activeText]}>
+          <Text style={[styles.buttonText, value && styles.activeText]}>
             {rightLabel}
           </Text>
         </Pressable>
       </View>
 
-      {/* Show Different Components Based on State */}
-      {isToggled ? rightComponent : leftComponent}
+      {value ? rightComponent : leftComponent}
     </>
   );
 };
@@ -76,8 +72,12 @@ const styles = StyleSheet.create({
     borderRadius: 6,
   },
   activeButton: {
+    borderRadius: 4,
+    height: 27,
     backgroundColor: "#ffffff", // Active color
-    shadowOffset: { width: 0, height: 1.5 },
+    elevation: 0.5,
+    paddingHorizontal: 1.5,
+
     shadowColor: "#000",
     shadowOpacity: 0.1,
   },

--- a/components/custom/UserInterface/components/UserArea/components/UserAreaWasteProducerActions/UserAreaWasteProducerActions.tsx
+++ b/components/custom/UserInterface/components/UserArea/components/UserAreaWasteProducerActions/UserAreaWasteProducerActions.tsx
@@ -109,7 +109,7 @@ const UserAreaWasteProducerActions: FC<UserAreaWasteProducerActions> = () => {
         <Button title="Endereços" onPress={handleAddressesButton} />
       </View>
       <View className="mb-2">
-        <Button title="Residos" onPress={handleResiduesButton} />
+        <Button title="Residuos" onPress={handleResiduesButton} />
       </View>
       <View className="mb-2">
         <Button title="Coletas" onPress={handleCollectsButton} />

--- a/components/custom/UserInterface/components/UserArea/components/UserAreaWasteProducerActions/components/WasteProducerUserCollects/WasteProducerUserCollects.tsx
+++ b/components/custom/UserInterface/components/UserArea/components/UserAreaWasteProducerActions/components/WasteProducerUserCollects/WasteProducerUserCollects.tsx
@@ -69,6 +69,11 @@ const WasteProducerUserCollects: FC<WasteProducerUserCollectsProps> = ({
 
           {error && <Text className="text-red-500 mt-2">{error}</Text>}
           {loading && <ActivityIndicator size="large" color="#4B9CD3" />}
+          {!loading && collects.length === 0 && (
+            <Text className="text-gray-500 mt-2">
+              Nenhuma coleta cadastrada ainda.
+            </Text>
+          )}
 
           <FlatList
             data={collects}

--- a/components/custom/UserInterface/components/UserArea/components/UserAreaWasteProducerActions/components/WasteProducerUserResidues/WasteProducerUserResidues.tsx
+++ b/components/custom/UserInterface/components/UserArea/components/UserAreaWasteProducerActions/components/WasteProducerUserResidues/WasteProducerUserResidues.tsx
@@ -79,10 +79,10 @@ const WasteProducerUserResidues: FC<WasteProducerUserResiduesProps> = ({
                 </TouchableOpacity>
               </View>
               <Text className="text-lg font-bold mb-2">
-                Resídos Cadastrados
+                Residuos Cadastrados
               </Text>
               <Text className="text-sm text-gray-600 mb-4">
-                Aqui estão os resídos que você cadastrou.
+                Aqui estão os residuos que você cadastrou.
               </Text>
 
               {error && <Text className="text-red-500 mb-4">{error}</Text>}
@@ -92,7 +92,7 @@ const WasteProducerUserResidues: FC<WasteProducerUserResiduesProps> = ({
                 </View>
               ) : residues.length === 0 ? (
                 <Text className="text-gray-500">
-                  Nenhum endereço cadastrado ainda.
+                  Nenhum resído cadastrado ainda.
                 </Text>
               ) : (
                 uniqueResidues.map((item) => (


### PR DESCRIPTION
# Descrição:

Nesse PR corrigimos alguns erros de grafia e adaptamos algumas interfaces para melhorar a experiência de usuário.

- Alterações notáveis

Durante o primeiro registro de uma coleta, como não existirá nenhum endereço vinculado a conta do usuário , em vez de exibirmos o `InterfaceSwitch` que permite o usuário utilizar um endereço existente, ou registrar um novo endereço, estamos exibindo apenas o `AddNewAdress`.

Melhoramos os estilos do `InterfaceSwitch`  e corrigimos o comportamento inesperado do `RegisterUserTypePicker` que renderizava dois diferentes selects, adicionamos estilos inciais.

Refatoramos o comportamento do SplashScreen, dessa forma sempre que o app for aberto vamos utilizar a SplashScreen, isso só será aplicado aos builds `production` e `preview` nas próximas builds