### PR TITLE
[SCRUM-137]:  FE Criar interface de calendario com coletas registradas

### DIFF
--- a/app/CalendarScreen.tsx
+++ b/app/CalendarScreen.tsx
@@ -1,0 +1,21 @@
+import { CalendarInterface } from "@/components/custom/UserInterface/components/CalendarInterface";
+import { WasteProducerProvider } from "@/context/WasteProducerContext";
+import { useRouter } from "expo-router";
+import React from "react";
+import { Button } from "react-native";
+
+const CalendarScreen = () => {
+  const router = useRouter();
+  return (
+    <WasteProducerProvider>
+      <Button
+        title="Voltar"
+        onPress={() => {
+          router.back();
+        }}
+      />
+      <CalendarInterface />
+    </WasteProducerProvider>
+  );
+};
+export default CalendarScreen;

--- a/app/Home.tsx
+++ b/app/Home.tsx
@@ -110,7 +110,7 @@ const Home = () => {
       {needsUserType ? (
         <UserTypePicker onSelect={handleUserTypeSelect} />
       ) : (
-        <View className="rounded-sm items-center justify-center p-4 w-full h-full">
+        <View className="rounded-sm items-center justify-center p-1 w-full h-full">
           {user && <UserInterface user={user} onLogout={onLogout} />}
         </View>
       )}

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -35,6 +35,7 @@ const Layout = () => {
           <Stack screenOptions={{ headerShown: false }}>
             <Stack.Screen name="Home" />
             <Stack.Screen name="AuthScreen" />
+            <Stack.Screen name="CalendarScreen" />
           </Stack>
           <RootLayoutNav splashDone={splashDone} />
         </>

--- a/components/custom/UserInterface/components/CalendarInterface/CalendarInterface.tsx
+++ b/components/custom/UserInterface/components/CalendarInterface/CalendarInterface.tsx
@@ -1,0 +1,32 @@
+import React from "react";
+
+import { Calendar } from "./components/Calendar";
+import { Text, View } from "react-native";
+import { CalendarCheck, LucideCalendarDays } from "lucide-react-native";
+
+const CalendarInterface = () => {
+  return (
+    <View className="flex-1 ">
+      <View className="">
+        <View className="flex-row items-center justify-start px-1">
+          <View className="mr-2">
+            <CalendarCheck size={32} color="#000" />
+          </View>
+          <View className="mt-2">
+            <Text className="text-left text-2xl font-bold  ">Calendário</Text>
+          </View>
+        </View>
+        <View className="px-2 my-2">
+          <Text className="text-left text-sm font-bold">
+            Visualize suas coletas agendadas e os dias disponíveis para
+            agendamento.
+          </Text>
+        </View>
+      </View>
+
+      <Calendar />
+    </View>
+  );
+};
+
+export default CalendarInterface;

--- a/components/custom/UserInterface/components/CalendarInterface/CalendarInterface.tsx
+++ b/components/custom/UserInterface/components/CalendarInterface/CalendarInterface.tsx
@@ -1,8 +1,7 @@
 import React from "react";
-
 import { Calendar } from "./components/Calendar";
 import { Text, View } from "react-native";
-import { CalendarCheck, LucideCalendarDays } from "lucide-react-native";
+import { CalendarCheck } from "lucide-react-native";
 
 const CalendarInterface = () => {
   return (

--- a/components/custom/UserInterface/components/CalendarInterface/components/Calendar/Calendar.tsx
+++ b/components/custom/UserInterface/components/CalendarInterface/components/Calendar/Calendar.tsx
@@ -1,0 +1,18 @@
+import React, { useState } from "react";
+import { View } from "react-native";
+import { renderCalendarView } from "../../utils";
+
+const Calendar = () => {
+  // State to manage the selected view type: 'week' or 'day'
+  const [viewType, setViewType] = useState<"week" | "day">("week");
+
+  const handleViewChange = (newView: "week" | "day") => setViewType(newView);
+
+  return (
+    <View className="flex-1">
+      {renderCalendarView(viewType, handleViewChange)}
+    </View>
+  );
+};
+
+export default Calendar;

--- a/components/custom/UserInterface/components/CalendarInterface/components/Calendar/Calendar.tsx
+++ b/components/custom/UserInterface/components/CalendarInterface/components/Calendar/Calendar.tsx
@@ -1,16 +1,24 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { View } from "react-native";
 import { renderCalendarView } from "../../utils";
+import { useWasteProducer } from "@/context/WasteProducerContext";
 
 const Calendar = () => {
+  const { collects, fetchCollects } = useWasteProducer();
   // State to manage the selected view type: 'week' or 'day'
   const [viewType, setViewType] = useState<"week" | "day">("week");
 
   const handleViewChange = (newView: "week" | "day") => setViewType(newView);
 
+  useEffect(() => {
+    if (collects.length === 0) {
+      fetchCollects();
+    } else return;
+  }, []);
+
   return (
     <View className="flex-1">
-      {renderCalendarView(viewType, handleViewChange)}
+      {renderCalendarView(viewType, handleViewChange, collects)}
     </View>
   );
 };

--- a/components/custom/UserInterface/components/CalendarInterface/components/Calendar/index.ts
+++ b/components/custom/UserInterface/components/CalendarInterface/components/Calendar/index.ts
@@ -1,0 +1,1 @@
+export { default as Calendar } from "./Calendar";

--- a/components/custom/UserInterface/components/CalendarInterface/constants/styles.tsx
+++ b/components/custom/UserInterface/components/CalendarInterface/constants/styles.tsx
@@ -1,0 +1,93 @@
+import { StyleSheet } from "react-native";
+
+const styles = StyleSheet.create({
+  calendarViewContainer: {
+    flex: 1,
+    paddingHorizontal: 4,
+  },
+  yearText: {
+    fontSize: 28,
+    fontWeight: "700",
+    color: "#333",
+    textAlign: "left",
+  },
+  headerContainerRowStyle: {
+    borderBottomWidth: 0,
+    zIndex: 1,
+    backgroundColor: "#2196f3",
+    elevation: 2,
+    borderRightWidth: 0,
+    borderLeftWidth: 0,
+    width: 35,
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  headerTextStyle: {
+    width: 40,
+    fontSize: 10,
+    color: "#fff",
+    fontWeight: "bold",
+  },
+  hourTextStyle: {
+    color: "#333",
+    fontSize: 12,
+  },
+  eventContainerStyle: {
+    borderRadius: 8,
+    margin: 3,
+    shadowColor: "#000",
+    shadowOpacity: 0.1,
+    shadowRadius: 4,
+    shadowOffset: { width: 0, height: 2 },
+    elevation: 3,
+  },
+  gridColumnStyle: {
+    borderRightColor: "#fff",
+    borderRightWidth: 1.5,
+  },
+  gridRowStyle: {
+    borderBottomColor: "#fff",
+    borderBottomWidth: 1.5,
+  },
+  dayHeaderContainer: {
+    display: "flex",
+    flexDirection: "column",
+    width: "100%",
+    zIndex: 10,
+  },
+  dayHeaderTopLabel: {
+    fontSize: 10,
+    color: "#fcfcfc",
+    fontWeight: "bold",
+    textAlign: "center",
+  },
+  dayHeaderBottomLabel: {
+    fontSize: 16,
+    color: "#fcfcfc",
+    fontWeight: "300",
+    textAlign: "center",
+  },
+  viewToggleContainer: {
+    flexDirection: "row",
+    justifyContent: "center",
+  },
+  activeButton: {
+    backgroundColor: "#2196f3",
+  },
+  toggleButtonText: {
+    color: "#fff",
+    fontSize: 12,
+  },
+  toggleButton: {
+    minWidth: 60,
+    height: 30,
+    justifyContent: "center",
+    alignItems: "center",
+    backgroundColor: "#4caf50",
+    borderRadius: 1,
+    marginLeft: 3,
+    marginTop: 3,
+  },
+});
+
+export default styles;

--- a/components/custom/UserInterface/components/CalendarInterface/constants/styles.tsx
+++ b/components/custom/UserInterface/components/CalendarInterface/constants/styles.tsx
@@ -13,17 +13,19 @@ const styles = StyleSheet.create({
   },
   headerContainerRowStyle: {
     borderBottomWidth: 0,
+    display: "flex",
+
     zIndex: 1,
+    width: 54,
+    paddingHorizontal: 5,
     backgroundColor: "#2196f3",
     elevation: 2,
     borderRightWidth: 0,
     borderLeftWidth: 0,
-    width: 35,
     justifyContent: "center",
     alignItems: "center",
   },
   headerTextStyle: {
-    width: 40,
     fontSize: 10,
     color: "#fff",
     fontWeight: "bold",
@@ -43,17 +45,15 @@ const styles = StyleSheet.create({
   },
   gridColumnStyle: {
     borderRightColor: "#fff",
-    borderRightWidth: 1.5,
+    borderRightWidth: 1,
   },
   gridRowStyle: {
     borderBottomColor: "#fff",
-    borderBottomWidth: 1.5,
+    borderBottomWidth: 1,
   },
   dayHeaderContainer: {
     display: "flex",
     flexDirection: "column",
-    width: "100%",
-    zIndex: 10,
   },
   dayHeaderTopLabel: {
     fontSize: 10,

--- a/components/custom/UserInterface/components/CalendarInterface/index.ts
+++ b/components/custom/UserInterface/components/CalendarInterface/index.ts
@@ -1,0 +1,1 @@
+export { default as CalendarInterface } from "./CalendarInterface";

--- a/components/custom/UserInterface/components/CalendarInterface/utils/index.tsx
+++ b/components/custom/UserInterface/components/CalendarInterface/utils/index.tsx
@@ -1,0 +1,210 @@
+import { format } from "date-fns";
+import React from "react";
+import { StyleSheet, Text, TouchableOpacity, View } from "react-native";
+import WeekView from "react-native-week-view";
+
+interface EventProps {
+  id: number;
+  description: string;
+  startDate: Date;
+  endDate: Date;
+  color: string;
+  eventKind: "block" | "standard";
+  resolveOverlap: "stack" | "lane" | "ignore";
+  stackKey: string;
+}
+
+const renderViewButtons = ({
+  handleViewChange,
+}: {
+  handleViewChange: (newView: "week" | "day") => void;
+}) => {
+  const styles = StyleSheet.create({
+    viewToggleContainer: {
+      flexDirection: "row",
+      justifyContent: "center",
+    },
+    activeButton: {
+      backgroundColor: "#2196f3",
+    },
+    toggleButtonText: {
+      color: "#fff",
+      fontSize: 12,
+    },
+    toggleButton: {
+      minWidth: 60,
+      height: 30,
+      justifyContent: "center",
+      alignItems: "center",
+      backgroundColor: "#4caf50",
+      borderRadius: 1,
+      marginLeft: 3,
+      marginTop: 3,
+    },
+  });
+
+  return (
+    <View style={styles.viewToggleContainer}>
+      <TouchableOpacity
+        style={[styles.toggleButton, styles.activeButton]}
+        onPress={() => handleViewChange("week")}
+      >
+        <Text style={styles.toggleButtonText}>Semana</Text>
+      </TouchableOpacity>
+      <TouchableOpacity
+        style={[styles.toggleButton, styles.activeButton]}
+        onPress={() => handleViewChange("day")}
+      >
+        <Text style={styles.toggleButtonText}>Dia</Text>
+      </TouchableOpacity>
+    </View>
+  );
+};
+
+const renderDayHeader = (props: any) => {
+  const styles = StyleSheet.create({
+    dayHeaderContainer: {
+      display: "flex",
+      flexDirection: "column",
+      width: "100%",
+      zIndex: 10,
+    },
+    dayHeaderTopLabel: {
+      fontSize: 10,
+      color: "#fcfcfc",
+      fontWeight: "bold",
+      textAlign: "center",
+    },
+    dayHeaderBottomLabel: {
+      fontSize: 16,
+      color: "#fcfcfc",
+      fontWeight: "300",
+      textAlign: "center",
+    },
+  });
+  const dayOfWeek = format(props.date, "EEE"); // Get the full day name, e.g., "Monday"
+  const dayNumber = format(props.date, "d"); // Get the day number, e.g., "25"
+  return (
+    <View style={styles.dayHeaderContainer}>
+      <View className=" bg-[#4ea3e8] justify-center  w-full h-full">
+        <Text style={styles.dayHeaderTopLabel}>{dayOfWeek}</Text>
+        <Text style={styles.dayHeaderBottomLabel}>{dayNumber}</Text>
+      </View>
+    </View>
+  );
+};
+
+const renderCalendarView = (
+  viewType: string,
+  handleViewChange: (newView: "week" | "day") => void
+) => {
+  const formattedYear = format(new Date(), "yyyy"); // Display only the month name (e.g., "April")
+  const styles = StyleSheet.create({
+    calendarViewContainer: {
+      flex: 1,
+      paddingHorizontal: 4,
+    },
+    yearText: {
+      fontSize: 28,
+      fontWeight: "700",
+      color: "#333",
+      textAlign: "left",
+    },
+    headerContainerRowStyle: {
+      borderBottomWidth: 0,
+      zIndex: 1,
+      backgroundColor: "#2196f3",
+      elevation: 2,
+      borderRightWidth: 0,
+      borderLeftWidth: 0,
+      width: 35,
+      justifyContent: "center",
+      alignItems: "center",
+    },
+    dayHeaderContainer: {
+      display: "flex",
+      flexDirection: "column",
+      width: "100%",
+      zIndex: 10,
+    },
+    headerTextStyle: {
+      width: 40,
+      fontSize: 10,
+      color: "#fff",
+      fontWeight: "bold",
+    },
+    hourTextStyle: {
+      color: "#333",
+      fontSize: 12,
+    },
+    eventContainerStyle: {
+      borderRadius: 8,
+      margin: 3,
+      shadowColor: "#000",
+      shadowOpacity: 0.1,
+      shadowRadius: 4,
+      shadowOffset: { width: 0, height: 2 },
+      elevation: 3,
+    },
+    gridColumnStyle: {
+      borderRightColor: "#fff",
+      borderRightWidth: 1.5,
+    },
+    gridRowStyle: {
+      borderBottomColor: "#fff",
+      borderBottomWidth: 1.5,
+    },
+  });
+
+  const events: EventProps[] = [
+    {
+      id: 1,
+      description: "Pickup Waste",
+      startDate: new Date("2025-04-24T10:00:00"),
+      endDate: new Date("2025-04-24T11:30:00"),
+      color: "#4caf50", // green
+      eventKind: "standard",
+      resolveOverlap: "stack",
+      stackKey: "pickup-waste",
+    },
+    {
+      id: 2,
+      description: "Delivery Materials",
+      startDate: new Date("2025-04-25T14:00:00"),
+      endDate: new Date("2025-04-25T15:30:00"),
+      color: "#2196f3", // blue
+      eventKind: "standard",
+      resolveOverlap: "stack",
+      stackKey: "delivery-materials",
+    },
+  ];
+  return (
+    <View style={styles.calendarViewContainer}>
+      <View style={{ flexDirection: "row", justifyContent: "space-between" }}>
+        <Text style={styles.yearText}>{formattedYear}</Text>
+        {renderViewButtons({ handleViewChange })}
+      </View>
+      <View style={{ flex: 1, backgroundColor: "#fff" }}>
+        <WeekView
+          events={events}
+          selectedDate={new Date()}
+          numberOfDays={viewType === "week" ? 7 : 1} // 7 days for week view, 1 day for day view
+          headerStyle={styles.headerContainerRowStyle}
+          DayHeaderComponent={renderDayHeader}
+          locale="pt-BR"
+          headerTextStyle={styles.headerTextStyle}
+          timesColumnWidth={30}
+          hoursInDisplay={12}
+          hourTextStyle={styles.hourTextStyle}
+          eventContainerStyle={styles.eventContainerStyle}
+          gridColumnStyle={styles.gridColumnStyle}
+          gridRowStyle={styles.gridRowStyle}
+          onEventPress={(event) => console.log("Pressed event:", event)}
+          onGridClick={(event) => console.log("Pressed empty:", event)}
+        />
+      </View>
+    </View>
+  );
+};
+
+export { renderViewButtons, renderCalendarView };

--- a/components/custom/UserInterface/components/CalendarInterface/utils/index.tsx
+++ b/components/custom/UserInterface/components/CalendarInterface/utils/index.tsx
@@ -1,7 +1,8 @@
-import { format } from "date-fns";
 import React from "react";
-import { StyleSheet, Text, TouchableOpacity, View } from "react-native";
+import { Text, TouchableOpacity, View } from "react-native";
+import { format } from "date-fns";
 import WeekView from "react-native-week-view";
+import styles from "../constants/styles";
 
 interface EventProps {
   id: number;
@@ -19,30 +20,6 @@ const renderViewButtons = ({
 }: {
   handleViewChange: (newView: "week" | "day") => void;
 }) => {
-  const styles = StyleSheet.create({
-    viewToggleContainer: {
-      flexDirection: "row",
-      justifyContent: "center",
-    },
-    activeButton: {
-      backgroundColor: "#2196f3",
-    },
-    toggleButtonText: {
-      color: "#fff",
-      fontSize: 12,
-    },
-    toggleButton: {
-      minWidth: 60,
-      height: 30,
-      justifyContent: "center",
-      alignItems: "center",
-      backgroundColor: "#4caf50",
-      borderRadius: 1,
-      marginLeft: 3,
-      marginTop: 3,
-    },
-  });
-
   return (
     <View style={styles.viewToggleContainer}>
       <TouchableOpacity
@@ -62,26 +39,6 @@ const renderViewButtons = ({
 };
 
 const renderDayHeader = (props: any) => {
-  const styles = StyleSheet.create({
-    dayHeaderContainer: {
-      display: "flex",
-      flexDirection: "column",
-      width: "100%",
-      zIndex: 10,
-    },
-    dayHeaderTopLabel: {
-      fontSize: 10,
-      color: "#fcfcfc",
-      fontWeight: "bold",
-      textAlign: "center",
-    },
-    dayHeaderBottomLabel: {
-      fontSize: 16,
-      color: "#fcfcfc",
-      fontWeight: "300",
-      textAlign: "center",
-    },
-  });
   const dayOfWeek = format(props.date, "EEE"); // Get the full day name, e.g., "Monday"
   const dayNumber = format(props.date, "d"); // Get the day number, e.g., "25"
   return (
@@ -96,88 +53,44 @@ const renderDayHeader = (props: any) => {
 
 const renderCalendarView = (
   viewType: string,
-  handleViewChange: (newView: "week" | "day") => void
+  handleViewChange: (newView: "week" | "day") => void,
+  collects: any[]
 ) => {
   const formattedYear = format(new Date(), "yyyy"); // Display only the month name (e.g., "April")
-  const styles = StyleSheet.create({
-    calendarViewContainer: {
-      flex: 1,
-      paddingHorizontal: 4,
-    },
-    yearText: {
-      fontSize: 28,
-      fontWeight: "700",
-      color: "#333",
-      textAlign: "left",
-    },
-    headerContainerRowStyle: {
-      borderBottomWidth: 0,
-      zIndex: 1,
-      backgroundColor: "#2196f3",
-      elevation: 2,
-      borderRightWidth: 0,
-      borderLeftWidth: 0,
-      width: 35,
-      justifyContent: "center",
-      alignItems: "center",
-    },
-    dayHeaderContainer: {
-      display: "flex",
-      flexDirection: "column",
-      width: "100%",
-      zIndex: 10,
-    },
-    headerTextStyle: {
-      width: 40,
-      fontSize: 10,
-      color: "#fff",
-      fontWeight: "bold",
-    },
-    hourTextStyle: {
-      color: "#333",
-      fontSize: 12,
-    },
-    eventContainerStyle: {
-      borderRadius: 8,
-      margin: 3,
-      shadowColor: "#000",
-      shadowOpacity: 0.1,
-      shadowRadius: 4,
-      shadowOffset: { width: 0, height: 2 },
-      elevation: 3,
-    },
-    gridColumnStyle: {
-      borderRightColor: "#fff",
-      borderRightWidth: 1.5,
-    },
-    gridRowStyle: {
-      borderBottomColor: "#fff",
-      borderBottomWidth: 1.5,
-    },
-  });
 
-  const events: EventProps[] = [
-    {
-      id: 1,
-      description: "Pickup Waste",
-      startDate: new Date("2025-04-24T10:00:00"),
-      endDate: new Date("2025-04-24T11:30:00"),
-      color: "#4caf50", // green
-      eventKind: "standard",
-      resolveOverlap: "stack",
-      stackKey: "pickup-waste",
-    },
-    {
-      id: 2,
-      description: "Delivery Materials",
-      startDate: new Date("2025-04-25T14:00:00"),
-      endDate: new Date("2025-04-25T15:30:00"),
-      color: "#2196f3", // blue
-      eventKind: "standard",
-      resolveOverlap: "stack",
-      stackKey: "delivery-materials",
-    },
-  ];
+  const isValidDate = (date: any) => {
+    return date instanceof Date && !isNaN(date.getTime());
+  };
+
+  const events: EventProps[] = collects
+    .filter((collect: any) => {
+      if (!collect || !collect.dateTime) return false;
+
+      const date = new Date(collect.dateTime);
+      return isValidDate(date);
+    })
+    .map((collect: any) => {
+      const startDate = new Date(collect.dateTime);
+      const EVENT_DURATION_MINUTES = 60;
+      const endDate = new Date(
+        startDate.getTime() + EVENT_DURATION_MINUTES * 60 * 1000
+      );
+      console.log("startDate:", startDate.toISOString());
+      console.log("endDate:", endDate.toISOString());
+      return {
+        id: collect._id,
+        description: collect.eventName || "Sem nome",
+        startDate,
+        endDate,
+        color: collect.isSigned ? "#4caf50" : "#f44336",
+        eventKind: "standard",
+        resolveOverlap: "stack",
+        stackKey: collect.eventName || "coleta",
+      };
+    });
+
+  console.log("Events:", JSON.stringify(events, null, 2));
+
   return (
     <View style={styles.calendarViewContainer}>
       <View style={{ flexDirection: "row", justifyContent: "space-between" }}>

--- a/components/custom/UserInterface/components/CalendarInterface/utils/index.tsx
+++ b/components/custom/UserInterface/components/CalendarInterface/utils/index.tsx
@@ -43,10 +43,8 @@ const renderDayHeader = (props: any) => {
   const dayNumber = format(props.date, "d"); // Get the day number, e.g., "25"
   return (
     <View style={styles.dayHeaderContainer}>
-      <View className=" bg-[#4ea3e8] justify-center  w-full h-full">
-        <Text style={styles.dayHeaderTopLabel}>{dayOfWeek}</Text>
-        <Text style={styles.dayHeaderBottomLabel}>{dayNumber}</Text>
-      </View>
+      <Text style={styles.dayHeaderTopLabel}>{dayOfWeek}</Text>
+      <Text style={styles.dayHeaderBottomLabel}>{dayNumber}</Text>
     </View>
   );
 };
@@ -75,8 +73,7 @@ const renderCalendarView = (
       const endDate = new Date(
         startDate.getTime() + EVENT_DURATION_MINUTES * 60 * 1000
       );
-      console.log("startDate:", startDate.toISOString());
-      console.log("endDate:", endDate.toISOString());
+
       return {
         id: collect._id,
         description: collect.eventName || "Sem nome",
@@ -89,16 +86,16 @@ const renderCalendarView = (
       };
     });
 
-  console.log("Events:", JSON.stringify(events, null, 2));
-
   return (
     <View style={styles.calendarViewContainer}>
       <View style={{ flexDirection: "row", justifyContent: "space-between" }}>
         <Text style={styles.yearText}>{formattedYear}</Text>
+
         {renderViewButtons({ handleViewChange })}
       </View>
       <View style={{ flex: 1, backgroundColor: "#fff" }}>
         <WeekView
+          nowLineColor="#4ea3e8"
           events={events}
           selectedDate={new Date()}
           numberOfDays={viewType === "week" ? 7 : 1} // 7 days for week view, 1 day for day view
@@ -106,8 +103,8 @@ const renderCalendarView = (
           DayHeaderComponent={renderDayHeader}
           locale="pt-BR"
           headerTextStyle={styles.headerTextStyle}
-          timesColumnWidth={30}
-          hoursInDisplay={12}
+          timesColumnWidth={viewType === "week" ? 48 : 52}
+          hoursInDisplay={viewType === "week" ? 8 : 6}
           hourTextStyle={styles.hourTextStyle}
           eventContainerStyle={styles.eventContainerStyle}
           gridColumnStyle={styles.gridColumnStyle}

--- a/components/custom/UserInterface/components/UserArea/UserArea.tsx
+++ b/components/custom/UserInterface/components/UserArea/UserArea.tsx
@@ -15,7 +15,7 @@ const UserArea: FC<UserAreaProps> = ({ user }) => {
   const isCollectsWaste = user.userType === "COLLECTS_WASTE";
 
   return (
-    <View className="w-full z-10">
+    <View className="w-full z-0">
       <View
         className={`justify-center border-l ${
           isProducesWaste && !isCollectsWaste ? "border-l-orange-300" : ""

--- a/components/custom/UserInterface/components/UserArea/components/UserAreaWasteProducerActions/components/WasteProducerUserCollects/WasteProducerUserCollects.tsx
+++ b/components/custom/UserInterface/components/UserArea/components/UserAreaWasteProducerActions/components/WasteProducerUserCollects/WasteProducerUserCollects.tsx
@@ -23,9 +23,6 @@ const WasteProducerUserCollects: FC<WasteProducerUserCollectsProps> = ({
     onClose();
   };
 
-  // Log when data is passed
-  console.log("Collects data:", collects);
-
   // Render each item in the FlatList
   const renderCollectItem = useCallback(({ item }: any) => {
     console.log("Rendering item:", item); // Log the item being rendered

--- a/components/custom/UserInterface/components/UserCenter/UserCenter.tsx
+++ b/components/custom/UserInterface/components/UserCenter/UserCenter.tsx
@@ -4,6 +4,7 @@ import { User } from "@/app/Home";
 import { WasteProducerCenterInterface } from "./components/WasteProducerCenterInterface";
 import { UseCenterGearMenu } from "./components/UserCenterGearMenu";
 import { UserCenterHeading } from "./components/UserCenterHeading";
+import { WasteProducerProvider } from "@/context/WasteProducerContext";
 
 interface UserCenterProps {
   user: User;
@@ -45,10 +46,12 @@ const UserCenter: FC<UserCenterProps> = ({ user, onLogout }) => {
         )}
 
         {isProducesWaste && (
-          <WasteProducerCenterInterface
-            user={user}
-            hasCollects={testVerification}
-          />
+          <WasteProducerProvider>
+            <WasteProducerCenterInterface
+              user={user}
+              hasCollects={testVerification}
+            />
+          </WasteProducerProvider>
         )}
         {isCollectsWaste && (
           <View className="w-full border rounded h-32 items-center justify-center">

--- a/components/custom/UserInterface/components/UserCenter/UserCenter.tsx
+++ b/components/custom/UserInterface/components/UserCenter/UserCenter.tsx
@@ -20,7 +20,7 @@ const UserCenter: FC<UserCenterProps> = ({ user, onLogout }) => {
   const testVerification = false;
 
   return (
-    <View className="w-full">
+    <View className="w-full z-10">
       <View
         className={`relative justify-center ${
           isProducesWaste && !isCollectsWaste ? "bg-orange-100" : ""
@@ -42,6 +42,7 @@ const UserCenter: FC<UserCenterProps> = ({ user, onLogout }) => {
           <UseCenterGearMenu
             setShowActions={setShowActions}
             onLogout={onLogout}
+            userType={user.userType}
           />
         )}
 

--- a/components/custom/UserInterface/components/UserCenter/components/UserCenterGearMenu/UseCenterGearMenu.tsx
+++ b/components/custom/UserInterface/components/UserCenter/components/UserCenterGearMenu/UseCenterGearMenu.tsx
@@ -1,9 +1,11 @@
-import { useRouter } from "expo-router";
-import { CalendarCheck } from "lucide-react-native";
 import React, { FC } from "react";
-import { View, Text, TouchableOpacity } from "react-native";
+import { LogoutMenuItem } from "./components/LogoutMenuItem";
+import { GearMenuContainer } from "./components/GearMenuContainer";
+import { gearMenuItemData } from "./utils";
+import { GearMenuItem } from "./components/GearMenuItem";
 
 interface UserCenterGearMenuProps {
+  userType?: string;
   onLogout?: () => Promise<any>;
   setShowActions: (show: boolean) => void;
 }
@@ -11,61 +13,32 @@ interface UserCenterGearMenuProps {
 const UseCenterGearMenu: FC<UserCenterGearMenuProps> = ({
   onLogout,
   setShowActions,
+  userType,
 }) => {
-  const router = useRouter();
+  const ProducesWasteUser = userType === "PRODUCES_WASTE";
+  const CollectsWasteUser = userType === "COLLECTS_WASTE";
+  const isWasteProducer = ProducesWasteUser && !CollectsWasteUser;
+  const isWasteCollector = !ProducesWasteUser && CollectsWasteUser;
   return (
-    <View className="absolute top-10 right-4 bg-white p-2 rounded shadow z-10">
-      <TouchableOpacity
-        className="py-1"
-        onPress={() => {
-          console.log("Edit Profile");
-          setShowActions(false);
-        }}
-      >
-        <Text>Meu Perfil</Text>
-        <TouchableOpacity
-          className="py-1"
-          onPress={() => {
-            console.log("Edit Profile");
-            setShowActions(false);
-          }}
-        >
-          <Text>Estatísticas da Conta</Text>
-        </TouchableOpacity>
-        <TouchableOpacity
-          className="py-1"
-          onPress={() => {
-            console.log("Edit Profile");
-            setShowActions(false);
-          }}
-        >
-          <Text>Histórico de Coletas</Text>
-        </TouchableOpacity>
-        <TouchableOpacity
-          className="py-1"
-          onPress={() => {
-            router.push("/CalendarScreen");
-            setShowActions(false);
-          }}
-        >
-          <View className="flex-row items-center justify-start ">
-            <View className="mr-2">
-              <CalendarCheck size={16} color="#000" />
-            </View>
-            <Text>Calendário</Text>
-          </View>
-        </TouchableOpacity>
-      </TouchableOpacity>
-      <TouchableOpacity
-        className="py-1"
-        onPress={() => {
-          setShowActions(false);
-          onLogout?.();
-        }}
-      >
-        <Text className="text-red-500">Sair</Text>
-      </TouchableOpacity>
-    </View>
+    <GearMenuContainer
+      isWasteCollector={isWasteCollector}
+      isWasteProducer={isWasteProducer}
+    >
+      {gearMenuItemData.map((item) => {
+        return (
+          <GearMenuItem
+            key={item.id}
+            title={item.title}
+            setShowActions={setShowActions}
+            isWasteProducer={isWasteProducer}
+            isWasteCollector={isWasteCollector}
+            redirectUrl={item.redirectUrl}
+          />
+        );
+      })}
+
+      <LogoutMenuItem setShowActions={setShowActions} onLogout={onLogout} />
+    </GearMenuContainer>
   );
 };
 export default UseCenterGearMenu;

--- a/components/custom/UserInterface/components/UserCenter/components/UserCenterGearMenu/UseCenterGearMenu.tsx
+++ b/components/custom/UserInterface/components/UserCenter/components/UserCenterGearMenu/UseCenterGearMenu.tsx
@@ -1,4 +1,6 @@
-import React, { FC, useState } from "react";
+import { useRouter } from "expo-router";
+import { CalendarCheck } from "lucide-react-native";
+import React, { FC } from "react";
 import { View, Text, TouchableOpacity } from "react-native";
 
 interface UserCenterGearMenuProps {
@@ -10,6 +12,7 @@ const UseCenterGearMenu: FC<UserCenterGearMenuProps> = ({
   onLogout,
   setShowActions,
 }) => {
+  const router = useRouter();
   return (
     <View className="absolute top-10 right-4 bg-white p-2 rounded shadow z-10">
       <TouchableOpacity
@@ -37,6 +40,20 @@ const UseCenterGearMenu: FC<UserCenterGearMenuProps> = ({
           }}
         >
           <Text>Histórico de Coletas</Text>
+        </TouchableOpacity>
+        <TouchableOpacity
+          className="py-1"
+          onPress={() => {
+            router.push("/CalendarScreen");
+            setShowActions(false);
+          }}
+        >
+          <View className="flex-row items-center justify-start ">
+            <View className="mr-2">
+              <CalendarCheck size={16} color="#000" />
+            </View>
+            <Text>Calendário</Text>
+          </View>
         </TouchableOpacity>
       </TouchableOpacity>
       <TouchableOpacity

--- a/components/custom/UserInterface/components/UserCenter/components/UserCenterGearMenu/components/GearMenuContainer/GearMenuContainer.tsx
+++ b/components/custom/UserInterface/components/UserCenter/components/UserCenterGearMenu/components/GearMenuContainer/GearMenuContainer.tsx
@@ -1,0 +1,27 @@
+import React, { FC } from "react";
+import { View } from "react-native";
+import { BlurView } from "expo-blur";
+import { GearMenuContainerProps } from "../../types";
+
+const GearMenuContainer: FC<GearMenuContainerProps> = ({
+  isWasteProducer,
+  isWasteCollector,
+  children,
+}) => {
+  return (
+    <View
+      className={`absolute top-10 right-4 mt-1 
+                ${isWasteProducer && "bg-orange-400/60"}
+                ${isWasteCollector && "bg-green-400/60"}
+               bg-orange-400/60 px-2 py-1 rounded-sm shadow z-10`}
+    >
+      <BlurView
+        intensity={40} // adjust the blur strength here (0 - 100)
+        tint="light" // options: "light", "dark", or "default"
+      />
+
+      {children}
+    </View>
+  );
+};
+export default GearMenuContainer;

--- a/components/custom/UserInterface/components/UserCenter/components/UserCenterGearMenu/components/GearMenuContainer/GearMenuContainer.tsx
+++ b/components/custom/UserInterface/components/UserCenter/components/UserCenterGearMenu/components/GearMenuContainer/GearMenuContainer.tsx
@@ -11,9 +11,9 @@ const GearMenuContainer: FC<GearMenuContainerProps> = ({
   return (
     <View
       className={`absolute top-10 right-4 mt-1 
-                ${isWasteProducer && "bg-orange-400/60"}
-                ${isWasteCollector && "bg-green-400/60"}
-               bg-orange-400/60 px-2 py-1 rounded-sm shadow z-10`}
+                ${isWasteProducer && !isWasteCollector && "bg-orange-400/60"}
+                ${isWasteCollector && !isWasteProducer && "bg-green-400/60"}
+               px-2 py-1 rounded-sm shadow z-10`}
     >
       <BlurView
         intensity={40} // adjust the blur strength here (0 - 100)

--- a/components/custom/UserInterface/components/UserCenter/components/UserCenterGearMenu/components/GearMenuContainer/index.ts
+++ b/components/custom/UserInterface/components/UserCenter/components/UserCenterGearMenu/components/GearMenuContainer/index.ts
@@ -1,0 +1,1 @@
+export { default as GearMenuContainer } from "./GearMenuContainer";

--- a/components/custom/UserInterface/components/UserCenter/components/UserCenterGearMenu/components/GearMenuItem/GearMenuItem.tsx
+++ b/components/custom/UserInterface/components/UserCenter/components/UserCenterGearMenu/components/GearMenuItem/GearMenuItem.tsx
@@ -1,0 +1,46 @@
+import { useRouter } from "expo-router";
+import React, { FC } from "react";
+import { View, Text, TouchableOpacity } from "react-native";
+import { determineIcon } from "../../utils";
+import { GearMenuItemProps, redirectUrlType } from "../../types";
+
+const GearMenuItem: FC<GearMenuItemProps> = ({
+  title,
+  setShowActions,
+  redirectUrl,
+  isWasteProducer,
+  isWasteCollector,
+}) => {
+  const router = useRouter();
+  const url: redirectUrlType = redirectUrl as redirectUrlType;
+
+  return (
+    <TouchableOpacity
+      className="py-2 rounded my-1 bg-slate-50 shadow-lg"
+      onPress={() => {
+        console.log("Clicado em : ", title);
+        console.log("Redirecting to: ", url);
+        router.push(url);
+        setShowActions(false);
+      }}
+    >
+      <View className="flex-row items-center justify-start w-60">
+        <View
+          className={`my-1 mx-2 rounded p-1 ${
+            isWasteProducer && "bg-orange-400"
+          } ${isWasteCollector && "bg-green-400"}`}
+        >
+          {determineIcon(title)}
+        </View>
+        <Text
+          className={`${isWasteProducer && "text-orange-800"} ${
+            isWasteCollector && "text-green-800"
+          } font-light text-xl`}
+        >
+          {title}
+        </Text>
+      </View>
+    </TouchableOpacity>
+  );
+};
+export default GearMenuItem;

--- a/components/custom/UserInterface/components/UserCenter/components/UserCenterGearMenu/components/GearMenuItem/index.ts
+++ b/components/custom/UserInterface/components/UserCenter/components/UserCenterGearMenu/components/GearMenuItem/index.ts
@@ -1,0 +1,1 @@
+export { default as GearMenuItem } from "./GearMenuItem";

--- a/components/custom/UserInterface/components/UserCenter/components/UserCenterGearMenu/components/LogoutMenuItem/LogoutMenuItem.tsx
+++ b/components/custom/UserInterface/components/UserCenter/components/UserCenterGearMenu/components/LogoutMenuItem/LogoutMenuItem.tsx
@@ -1,0 +1,27 @@
+import { LogOutIcon } from "lucide-react-native";
+import React, { FC } from "react";
+import { View, Text, TouchableOpacity } from "react-native";
+import { LogoutMenuItemProps } from "../../types";
+
+const LogoutMenuItem: FC<LogoutMenuItemProps> = ({
+  setShowActions,
+  onLogout,
+}) => {
+  return (
+    <TouchableOpacity
+      className="py-2 rounded my-1 bg-slate-50 shadow-lg"
+      onPress={() => {
+        setShowActions(false);
+        onLogout?.();
+      }}
+    >
+      <View className="flex-row items-center justify-start w-60">
+        <View className="my-1 mx-2 p-1">
+          <LogOutIcon size={18} color="#ef4444" />
+        </View>
+        <Text className="text-red-500 font-light text-xl">Sair</Text>
+      </View>
+    </TouchableOpacity>
+  );
+};
+export default LogoutMenuItem;

--- a/components/custom/UserInterface/components/UserCenter/components/UserCenterGearMenu/components/LogoutMenuItem/index.ts
+++ b/components/custom/UserInterface/components/UserCenter/components/UserCenterGearMenu/components/LogoutMenuItem/index.ts
@@ -1,0 +1,1 @@
+export { default as LogoutMenuItem } from "./LogoutMenuItem";

--- a/components/custom/UserInterface/components/UserCenter/components/UserCenterGearMenu/types/index.ts
+++ b/components/custom/UserInterface/components/UserCenter/components/UserCenterGearMenu/types/index.ts
@@ -1,0 +1,33 @@
+interface GearMenuItemProps {
+  setShowActions: (show: boolean) => void;
+  title: string;
+  redirectUrl: string;
+  isWasteProducer: boolean;
+  isWasteCollector: boolean;
+}
+
+interface GearMenuContainerProps {
+  isWasteProducer: boolean;
+  isWasteCollector: boolean;
+  children: React.ReactNode;
+}
+
+interface LogoutMenuItemProps {
+  onLogout?: () => Promise<any>;
+  setShowActions: (show: boolean) => void;
+}
+
+interface GearMenuContainerProps {
+  isWasteProducer: boolean;
+  isWasteCollector: boolean;
+  children: React.ReactNode;
+}
+
+type redirectUrlType = "/Home" | "/AuthScreen" | "/CalendarScreen";
+
+export {
+  GearMenuItemProps,
+  GearMenuContainerProps,
+  LogoutMenuItemProps,
+  redirectUrlType,
+};

--- a/components/custom/UserInterface/components/UserCenter/components/UserCenterGearMenu/utils/index.tsx
+++ b/components/custom/UserInterface/components/UserCenter/components/UserCenterGearMenu/utils/index.tsx
@@ -1,0 +1,46 @@
+import React from "react";
+import {
+  CalendarCheck,
+  ChartColumn,
+  HistoryIcon,
+  User2,
+} from "lucide-react-native";
+
+const gearMenuItemData = [
+  {
+    id: 1,
+    title: "Perfil",
+    redirectUrl: "/Home",
+  },
+  {
+    id: 2,
+    title: "Histórico",
+    redirectUrl: "/Home",
+  },
+  {
+    id: 3,
+    title: "Calendário",
+    redirectUrl: "/CalendarScreen",
+  },
+  {
+    id: 4,
+    title: "Relatório",
+    redirectUrl: "/Home",
+  },
+];
+
+const determineIcon = (title: string) => {
+  switch (title) {
+    case "Perfil":
+      return <User2 size={18} color="#f8fafc" />;
+    case "Histórico":
+      return <HistoryIcon size={18} color="#f8fafc" />;
+    case "Calendário":
+      return <CalendarCheck size={18} color="#f8fafc" />;
+    case "Relatório":
+      return <ChartColumn size={18} color="#f8fafc" />;
+    default:
+      return null;
+  }
+};
+export { gearMenuItemData, determineIcon };

--- a/components/custom/UserInterface/components/UserCenter/components/WasteProducerCenterInterface/WasteProducerCenterInterface.tsx
+++ b/components/custom/UserInterface/components/UserCenter/components/WasteProducerCenterInterface/WasteProducerCenterInterface.tsx
@@ -1,11 +1,22 @@
-import React from "react";
+import React, { FC } from "react";
 import { View } from "react-native";
 import { WasteProducerCenterActiveCollects } from "./components/WasteProducerCenterActiveCollects";
+import { User } from "@/app/Home";
 
-const WasteProducerCenterInterface = () => {
+interface WasteProducerCenterInterfaceProps {
+  user: User;
+  hasCollects: boolean;
+}
+const WasteProducerCenterInterface: FC<WasteProducerCenterInterfaceProps> = ({
+  user,
+  hasCollects,
+}) => {
   return (
     <View>
-      <WasteProducerCenterActiveCollects />
+      <WasteProducerCenterActiveCollects
+        user={user}
+        hasCollects={hasCollects}
+      />
     </View>
   );
 };

--- a/components/custom/UserInterface/components/UserCenter/components/WasteProducerCenterInterface/components/WasteProducerCenterActiveCollects/WasteProducerCenterActiveCollects.tsx
+++ b/components/custom/UserInterface/components/UserCenter/components/WasteProducerCenterInterface/components/WasteProducerCenterActiveCollects/WasteProducerCenterActiveCollects.tsx
@@ -4,8 +4,12 @@ import axios from "axios";
 import { format } from "date-fns";
 import { useAuth } from "@/context/AuthContext"; // adjust to your context path
 import Constants from "expo-constants";
+import { User } from "@/app/Home";
 
-interface WasteProducerCenterActiveCollectsProps {}
+interface WasteProducerCenterActiveCollectsProps {
+  user: User;
+  hasCollects: boolean;
+}
 
 interface CollectEvent {
   _id: string;
@@ -16,8 +20,8 @@ interface CollectEvent {
 
 const WasteProducerCenterActiveCollects: FC<
   WasteProducerCenterActiveCollectsProps
-> = () => {
-  const { API_URL, TOKEN_KEY } = Constants.expoConfig?.extra || {};
+> = ({ user, hasCollects }) => {
+  const { API_URL } = Constants.expoConfig?.extra || {};
   const { authState } = useAuth();
   const [activeCollects, setActiveCollects] = useState<CollectEvent[]>([]);
   const [loading, setLoading] = useState<boolean>(false);

--- a/package-lock.json
+++ b/package-lock.json
@@ -65,6 +65,7 @@
         "react-native-toast-message": "^2.2.1",
         "react-native-web": "~0.19.13",
         "react-native-webview": "13.12.5",
+        "react-native-week-view": "^0.30.0",
         "tailwindcss": "^3.4.17",
         "zod": "^3.24.2"
       },
@@ -12160,6 +12161,15 @@
         "mkdirp": "bin/cmd.js"
       }
     },
+    "node_modules/moment": {
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
+      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -13930,6 +13940,23 @@
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/react-native-week-view": {
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/react-native-week-view/-/react-native-week-view-0.30.0.tgz",
+      "integrity": "sha512-6BwkvtK6H7Ik6iHIrKxA+3gUnd0siSSafVfL8BPEg8AiCl5cbZuzk54EhJAyS5+uYoFzx+a8hNM9ZhjDWFmUcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "memoize-one": "^5.1.1",
+        "moment": "^2.19.3",
+        "prop-types": "^15.7.2"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*",
+        "react-native-gesture-handler": "^2.3.2",
+        "react-native-reanimated": "^2.4.1"
       }
     },
     "node_modules/react-native/node_modules/babel-plugin-syntax-hermes-parser": {

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "react-native-toast-message": "^2.2.1",
     "react-native-web": "~0.19.13",
     "react-native-webview": "13.12.5",
+    "react-native-week-view": "^0.30.0",
     "tailwindcss": "^3.4.17",
     "zod": "^3.24.2"
   },


### PR DESCRIPTION
[SCRUM-137](https://fatec-team-ext4gbza.atlassian.net/browse/SCRUM-137)

# Description

Nesse PR introduzimos lógica e componente para llidar com os Eventos de Coleta já registrados pelo user, como utilizamos o `react-native-week-view` não houve necessidade de gerar outro build.  Envolvemos os componentes necessário com o contexto implementado no [PR-24](https://github.com/wakenedo/recoleta-native/pull/24). Estamos utilizando o UserCenterGearMenu para chamar a página do calendário, com issso os estilos e estrutura foram alteradas para fortalecer a estrutura e implementações futuras.

### ComponentesAdicionados

`../components/CaledarInterface`
`../CalendarInterface/components/Calendar`

### Bibliotecas Adicionadas

`react-native-week-view`

### Screenshots
![Capturar](https://github.com/user-attachments/assets/ea2fc438-8ea4-4fe8-a590-7d02b445b0dc)
![Capturar1](https://github.com/user-attachments/assets/64cd4d8a-4be5-4715-80aa-19629cfac832)
![Capturar2](https://github.com/user-attachments/assets/2c3b924b-5687-4854-a4f4-e2ba54d73fac)
![Capturar3](https://github.com/user-attachments/assets/96e1cf2a-3b1a-4ce3-bd3c-0d11860d97f4)
![Capturar4](https://github.com/user-attachments/assets/c7d319c1-1a91-4bd7-82d0-f75524aff74d)


[SCRUM-137]: https://fatec-team-ext4gbza.atlassian.net/browse/SCRUM-137?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ