### PR TITLE
[FEAT] Introducing PriceTables logic from BE, MultipleResidues, WasteManagementInterface overhaul & Centralizing Types

### DIFF
--- a/app/Home.tsx
+++ b/app/Home.tsx
@@ -5,18 +5,6 @@ import { UserTypePicker } from "@/components/custom/UserTypePicker";
 import { UserInterface } from "@/components/custom/UserInterface";
 import { useUser } from "@/context/UserContext";
 
-export interface User {
-  email?: string;
-  photo?: string;
-  phone?: string;
-  document?: string;
-  status?: string;
-  accountType?: string;
-  firstName: string;
-  lastName: string;
-  userType: string;
-}
-
 const Home = () => {
   const { onLogout } = useAuth();
   const { user, updateUser } = useUser();

--- a/app/RegionPriceTableScreen.tsx
+++ b/app/RegionPriceTableScreen.tsx
@@ -1,0 +1,38 @@
+import { BackToHomeButton } from "@/components/custom/BackToHomeButton";
+import { RegionPriceTable } from "@/components/custom/RegionPriceTable";
+import { useAuth } from "@/context/AuthContext";
+import { useUser } from "@/context/UserContext";
+import React, { useEffect } from "react";
+import { ActivityIndicator, View } from "react-native";
+
+const RegionPriceTableScreen = () => {
+  const { authState } = useAuth();
+  const { loadUser, loading, user } = useUser();
+
+  useEffect(() => {
+    loadUser(); // Properly pass token to load user
+  }, []);
+
+  if (loading) {
+    return (
+      <View className="flex-1 justify-center items-center">
+        <ActivityIndicator size="large" color="#4B9CD3" />
+      </View>
+    );
+  }
+
+  console.log("PriceTable AuthState:", authState);
+  if (!authState?.token) return;
+
+  return (
+    <>
+      <BackToHomeButton user={user} />
+      <RegionPriceTable
+        token={authState.token}
+        region="sp" // ou dinamicamente: baseado no perfil, localização etc.
+      />
+    </>
+  );
+};
+
+export default RegionPriceTableScreen;

--- a/components/custom/AddressInterface/AddNewAddress/ChosenResidueCard/ChosenResidueCard.tsx
+++ b/components/custom/AddressInterface/AddNewAddress/ChosenResidueCard/ChosenResidueCard.tsx
@@ -5,8 +5,14 @@ import { Card } from "@/components/ui/card";
 import { useCollectFlow } from "@/context/CollectFlowContext";
 
 const ChosenResidueCard = () => {
-  const { selectedResidue, weight, selectedCondition, selectedPackage } =
-    useCollectFlow();
+  const {
+    selectedResidue,
+    weight,
+    selectedCondition,
+    selectedPackage,
+    selectedVariant,
+    estimatedValue,
+  } = useCollectFlow();
 
   if (!selectedResidue) return null;
 
@@ -32,6 +38,16 @@ const ChosenResidueCard = () => {
               {selectedResidue.name.toUpperCase()}
             </Text>
           </View>
+          <Text className="text-xs">
+            <Text className="font-normal">Tipo:</Text>{" "}
+            <Text className="font-medium">{selectedVariant?.label}</Text>
+          </Text>
+          <Text className="text-xs">
+            <Text className="font-normal">Valor estimado:</Text>{" "}
+            <Text className="font-medium">
+              R$ {estimatedValue?.toFixed(2) || "0.00"}
+            </Text>
+          </Text>
           <Text className="text-xs">
             <Text className="font-normal">Condição:</Text>{" "}
             <Text className="font-medium">{selectedCondition}</Text>

--- a/components/custom/AddressInterface/AddNewAddress/ChosenResidueCard/ChosenResidueCard.tsx
+++ b/components/custom/AddressInterface/AddNewAddress/ChosenResidueCard/ChosenResidueCard.tsx
@@ -17,49 +17,44 @@ const ChosenResidueCard = () => {
   if (!selectedResidue) return null;
 
   return (
-    <Card className=" mb-4 p-2  bg-green-200 shadow-lg text-slate-800">
-      <View className=" flex-row items-center  bg-zinc-50 rounded">
+    <Card className=" mb-4 p-2 rounded-none  bg-slate-100 border-orange-600 border-l shadow text-slate-800">
+      <View className=" flex-row items-center">
         {/* Image + Name */}
-        <View className="flex items-center justify-center p-5 ml-[3px] border-green-200 bg-green-100 border-r-2 rounded-l">
-          {selectedResidue.image && (
-            <Image
-              source={{ uri: selectedResidue.image }}
-              style={{
-                width: 75,
-                height: 75,
-              }}
-            />
-          )}
-        </View>
 
-        <View className=" p-3  ">
-          <View className="mb-2">
-            <Text className="text-lg  font-bold text-green-500">
-              {selectedResidue.name.toUpperCase()}
+        <View>
+          <Text className="text-xs uppercase font-bold text-orange-500 ">
+            {selectedResidue.name.toUpperCase()}
+          </Text>
+
+          <View className="flex flex-row items-center  ">
+            <Text className="font-medium mr-1 text-slate-700 mt-1">
+              {selectedVariant?.label}
+            </Text>
+            <Text className="font-medium text-xs text-slate-400 mt-1">
+              | R$ {selectedVariant?.pricePerKg}/kg
             </Text>
           </View>
-          <Text className="text-xs">
-            <Text className="font-normal">Tipo:</Text>{" "}
-            <Text className="font-medium">{selectedVariant?.label}</Text>
-          </Text>
-          <Text className="text-xs">
-            <Text className="font-normal">Valor estimado:</Text>{" "}
-            <Text className="font-medium">
-              R$ {estimatedValue?.toFixed(2) || "0.00"}
+          <View className="flex flex-row items-center ">
+            <Text className="text-xs text-slate-400 mr-1">
+              {selectedCondition}
             </Text>
-          </Text>
-          <Text className="text-xs">
-            <Text className="font-normal">Condição:</Text>{" "}
-            <Text className="font-medium">{selectedCondition}</Text>
-          </Text>
-          <Text className="text-xs">
-            <Text className="font-normal">Quantidade:</Text>{" "}
-            <Text className="font-medium">{weight} Kg</Text>
-          </Text>
-          <Text className="text-xs">
-            <Text className="font-normal">Embalagem:</Text>{" "}
-            <Text className="font-medium">{selectedPackage}</Text>
-          </Text>
+            <Text className="text-xs text-slate-400">| {selectedPackage}</Text>
+          </View>
+          <View className="flex flex-row items-center mr-1 ">
+            <View className="flex flex-row items-center ">
+              <Text className="text-xs text-slate-400 mr-1 mt-1">
+                Quantidade:
+              </Text>
+              <Text className="font-semibold text-slate-600">{weight} Kg</Text>
+            </View>
+            <View className="flex flex-row items-center mb-1  ml-20">
+              <Text className="text-xs text-slate-400 mr-1 mt-1">Preço:</Text>
+              <Text className="text-slate-600 text-sm font-semibold">R$ </Text>
+              <Text className="font-semibold text-slate-600">
+                {estimatedValue?.toFixed(2) || "0.00"}
+              </Text>
+            </View>
+          </View>
         </View>
       </View>
     </Card>

--- a/components/custom/AddressInterface/AddNewAddress/ChosenResiduesInterface/ChosenResiduesInterface.tsx
+++ b/components/custom/AddressInterface/AddNewAddress/ChosenResiduesInterface/ChosenResiduesInterface.tsx
@@ -1,12 +1,8 @@
-import { Residue } from "@/components/custom/WasteManagementInterface/types";
 import { Card } from "@/components/ui/card";
 import { useCollectFlow } from "@/context/CollectFlowContext";
 import React, { useEffect } from "react";
 import { ScrollView, Text, View } from "react-native";
-
-type ChosenResiduesInterfaceProps = {
-  residues: Residue[];
-};
+import { ChosenResiduesInterfaceProps } from "./types";
 
 const ChosenResiduesInterface: React.FC<ChosenResiduesInterfaceProps> = ({
   residues,

--- a/components/custom/AddressInterface/AddNewAddress/ChosenResiduesInterface/ChosenResiduesInterface.tsx
+++ b/components/custom/AddressInterface/AddNewAddress/ChosenResiduesInterface/ChosenResiduesInterface.tsx
@@ -1,0 +1,116 @@
+import { Residue } from "@/components/custom/WasteManagementInterface/types";
+import { Card } from "@/components/ui/card";
+import { useCollectFlow } from "@/context/CollectFlowContext";
+import React, { useEffect } from "react";
+import { ScrollView, Text, View } from "react-native";
+
+type ChosenResiduesInterfaceProps = {
+  residues: Residue[];
+};
+
+const ChosenResiduesInterface: React.FC<ChosenResiduesInterfaceProps> = ({
+  residues,
+}) => {
+  const { estimatedValue, setCollectFlowData } = useCollectFlow();
+  if (residues === undefined) return;
+
+  const calculateTotalOrderValue = (): number => {
+    if (!residues) return 0;
+
+    return residues.reduce((acc, r) => {
+      const weight = r.weight ?? 0;
+      const price = r.variant?.pricePerKg ?? 0;
+      return acc + weight * price;
+    }, 0);
+  };
+
+  useEffect(() => {
+    const total = calculateTotalOrderValue();
+    setCollectFlowData({ estimatedValue: total });
+  }, [residues]);
+
+  return (
+    <View>
+      <View>
+        <ScrollView className="flex-1 w-full max-h-72">
+          <View>
+            {residues.map((r) => {
+              const registeredWeight = r.weight;
+              const variantPricePerKilo = r.variant?.pricePerKg;
+              if (registeredWeight === undefined) return;
+              if (variantPricePerKilo === undefined) return;
+              const result = registeredWeight * variantPricePerKilo;
+              const calculateVariantEstimatedValue = () => {
+                return result;
+              };
+
+              return (
+                <View key={r.variant?.label} className="p-1">
+                  <Card className="p-2 rounded-none  bg-slate-100 border-orange-600 border-l shadow text-slate-800">
+                    <View className=" flex-row items-center">
+                      {/* Image + Name */}
+
+                      <View>
+                        <Text className="text-xs uppercase font-bold text-orange-500 ">
+                          {r.name.toUpperCase()}
+                        </Text>
+
+                        <View className="flex flex-row items-center  ">
+                          <Text className="font-medium mr-1 text-slate-700 mt-1">
+                            {r.variant?.label}
+                          </Text>
+                          <Text className="font-medium text-xs text-slate-400 mt-1">
+                            | R$ {r.variant?.pricePerKg}/kg
+                          </Text>
+                        </View>
+                        <View className="flex flex-row items-center ">
+                          <Text className="text-xs text-slate-400 mr-1">
+                            {r.condition}
+                          </Text>
+                          <Text className="text-xs text-slate-400">
+                            | {r.pkg}
+                          </Text>
+                        </View>
+                        <View className="flex flex-row items-center mr-1 ">
+                          <View className="flex flex-row items-center ">
+                            <Text className="text-xs text-slate-400 mr-1 mt-1">
+                              Quantidade:
+                            </Text>
+                            <Text className="font-semibold text-slate-600">
+                              {r.weight} Kg
+                            </Text>
+                          </View>
+                          <View className="flex flex-row items-center mb-1  ml-20">
+                            <Text className="text-xs text-slate-400 mr-1 mt-1">
+                              Preço:
+                            </Text>
+                            <Text className="text-slate-600 text-sm font-semibold">
+                              R${" "}
+                            </Text>
+                            <Text className="font-semibold text-slate-600">
+                              {calculateVariantEstimatedValue()?.toFixed(2) ||
+                                "0.00"}
+                            </Text>
+                          </View>
+                        </View>
+                      </View>
+                    </View>
+                  </Card>
+                </View>
+              );
+            })}
+          </View>
+        </ScrollView>
+      </View>
+      <View className="flex flex-row items-center bg-slate-100 w-full h-14 p-2 mt-2">
+        <Text className="text-xs text-slate-400 mt-1 mr-1">Valor total:</Text>
+        <Text className="text-base text-slate-500 font-medium">R$</Text>
+        <Text className="text-lg text-slate-600 font-semibold">
+          {" "}
+          {estimatedValue?.toFixed(2) ?? "0.00"}
+        </Text>
+      </View>
+    </View>
+  );
+};
+export default ChosenResiduesInterface;

--- a/components/custom/AddressInterface/AddNewAddress/ChosenResiduesInterface/index.ts
+++ b/components/custom/AddressInterface/AddNewAddress/ChosenResiduesInterface/index.ts
@@ -1,0 +1,1 @@
+export { default as ChosenResiduesInterface } from "./ChosenResiduesInterface";

--- a/components/custom/AddressInterface/AddNewAddress/ChosenResiduesInterface/types/index.ts
+++ b/components/custom/AddressInterface/AddNewAddress/ChosenResiduesInterface/types/index.ts
@@ -1,0 +1,7 @@
+import { Residue } from "@/components/custom/WasteManagementInterface/types";
+
+type ChosenResiduesInterfaceProps = {
+  residues: Residue[];
+};
+
+export { ChosenResiduesInterfaceProps };

--- a/components/custom/AddressInterface/AddNewAddress/components/AddNewAddressForm/AddNewAddressForm.tsx
+++ b/components/custom/AddressInterface/AddNewAddress/components/AddNewAddressForm/AddNewAddressForm.tsx
@@ -35,7 +35,7 @@ const AddNewAddressForm: FC<AddNewAddressFormProps> = ({
     <View className="">
       <View className="flex-row gap-x-4 ">
         <View className="flex-1">
-          <Text className="text-md font-bold mb-2 text-slate-800">CEP</Text>
+          <Text className="text-base font-bold text-orange-600 mb-2">CEP</Text>
           <View style={styles.container}>
             <View style={styles.inputWrapper}>
               <PinIcon size={18} color="#9CA3AF" style={styles.icon} />
@@ -52,7 +52,9 @@ const AddNewAddressForm: FC<AddNewAddressFormProps> = ({
         </View>
 
         <View className="flex-1">
-          <Text className="text-md font-bold mb-2 text-slate-800">Número</Text>
+          <Text className="text-base font-bold text-orange-600 mb-2">
+            Número
+          </Text>
           <View style={styles.container}>
             <View style={styles.inputWrapper}>
               <Hash size={18} color="#9CA3AF" style={styles.icon} />
@@ -68,11 +70,10 @@ const AddNewAddressForm: FC<AddNewAddressFormProps> = ({
         </View>
       </View>
       <View className="flex flex-col">
-        <View className="mb-2">
-          <Text className="text-md font-bold text-slate-800">
-            Rua/Logradouro
-          </Text>
-        </View>
+        <Text className="text-base font-bold text-orange-600 mb-2">
+          Rua/Logradouro
+        </Text>
+
         <View style={styles.container}>
           <View style={styles.inputWrapper}>
             <HouseIcon size={18} color="#9CA3AF" style={styles.icon} />
@@ -86,9 +87,9 @@ const AddNewAddressForm: FC<AddNewAddressFormProps> = ({
         </View>
       </View>
       <View className="flex flex-col">
-        <View className="mb-2">
-          <Text className="text-md font-bold text-slate-800">Complemento</Text>
-        </View>
+        <Text className="text-base font-bold text-orange-600 mb-2">
+          Complemento
+        </Text>
         <View style={styles.container}>
           <View style={styles.inputWrapper}>
             <MapPinPlus size={18} color="#9CA3AF" style={styles.icon} />
@@ -103,9 +104,7 @@ const AddNewAddressForm: FC<AddNewAddressFormProps> = ({
       </View>
 
       <View className="flex flex-col">
-        <View className="mb-2">
-          <Text className="text-md font-bold text-slate-800">Bairro</Text>
-        </View>
+        <Text className="text-base font-bold text-orange-600 mb-2">Bairro</Text>
         <View style={styles.container}>
           <View style={styles.inputWrapper}>
             <MapPinHouseIcon size={18} color="#9CA3AF" style={styles.icon} />
@@ -120,7 +119,9 @@ const AddNewAddressForm: FC<AddNewAddressFormProps> = ({
       </View>
       <View className="flex-row gap-x-4">
         <View className="flex-1">
-          <Text className="text-md font-bold mb-2 text-slate-800">Cidade</Text>
+          <Text className="text-base font-bold text-orange-600 mb-2">
+            Cidade
+          </Text>
           <View style={styles.container}>
             <View style={styles.inputWrapper}>
               <Building2 size={18} color="#9CA3AF" style={styles.icon} />
@@ -135,7 +136,9 @@ const AddNewAddressForm: FC<AddNewAddressFormProps> = ({
         </View>
 
         <View className="flex-1">
-          <Text className="text-md font-bold mb-2 text-slate-800">Estado</Text>
+          <Text className="text-base font-bold text-orange-600 mb-2">
+            Estado
+          </Text>
           <View style={styles.container}>
             <View style={styles.inputWrapper}>
               <MapPinned size={18} color="#9CA3AF" style={styles.icon} />

--- a/components/custom/AddressInterface/AddNewAddress/components/AddNewAddressViaGPS/AddNewAddressViaGPS.tsx
+++ b/components/custom/AddressInterface/AddNewAddress/components/AddNewAddressViaGPS/AddNewAddressViaGPS.tsx
@@ -67,7 +67,7 @@ const AddNewAddressViaGPS = () => {
 
   return (
     <View>
-      <Text className="text-md font-bold text-slate-800">
+      <Text className="text-orange-600 font-bold text-base mb-2">
         Usar localização atual
       </Text>
 

--- a/components/custom/AddressInterface/AddressInterface.tsx
+++ b/components/custom/AddressInterface/AddressInterface.tsx
@@ -1,9 +1,8 @@
 import React, { useEffect, useState } from "react";
-import { View } from "react-native";
+import { ScrollView, Text, View } from "react-native";
 import { useAddress } from "@/hooks/useAddress";
 import { Card } from "@/components/ui/card";
-import { Heading } from "@/components/ui/heading";
-import { Text } from "@/components/ui/text";
+
 import { InterfaceSwitch } from "../InterfaceSwitch";
 import AddNewAddress from "./AddNewAddress/AddNewAddress";
 import { ChosenResidueCard } from "./AddNewAddress/ChosenResidueCard";
@@ -13,13 +12,14 @@ import { Address } from "./types";
 import axios from "axios";
 import { useAuth } from "@/context/AuthContext";
 import { useCollectFlow } from "@/context/CollectFlowContext";
+import { ChosenResiduesInterface } from "./AddNewAddress/ChosenResiduesInterface";
 
 const AddressInterface: React.FC = ({}) => {
   const [hasRegisteredAddresses, setHasRegisteredAddresses] = useState(false);
   const [toggleDefault, setToggleDefault] = useState(false);
   const { authState } = useAuth();
   const { API_URL } = Constants.expoConfig?.extra || {};
-  const { setCollectFlowData, resetAddressData } = useCollectFlow();
+  const { setCollectFlowData, resetAddressData, residues } = useCollectFlow();
   const {
     latitude,
     longitude,
@@ -74,19 +74,39 @@ const AddressInterface: React.FC = ({}) => {
   };
 
   return (
-    <Card className="border border-zinc-300">
-      <View className="mb-6">
-        <Heading size="xs">Gerenciamento de Endereços para Coleta</Heading>
-        <Text size="xs" className="mt-2">
-          Visualize seus endereços cadastrados e adicione novos endereços para
-          coleta
+    <Card className="space-y-6 border-l rounded-md p-4 bg-white border-orange-300 shadow">
+      <View className="mb-4">
+        <Text className="text-base font-bold text-orange-600">
+          Gerenciamento de Endereços para Coleta
         </Text>
+        {hasRegisteredAddresses && (
+          <Text className="text-xs text-slate-600">
+            Visualize seus endereços cadastrados ou adicione novos endereços
+            para coleta
+          </Text>
+        )}
+        {!hasRegisteredAddresses && (
+          <Text className="text-xs text-slate-600">
+            Adicione novos endereços para coleta
+          </Text>
+        )}
       </View>
-      <View>
-        <Heading className="mb-2" size="xs">
-          Resido a cadastrar:
-        </Heading>
-        <ChosenResidueCard />
+      <View className="mb-2">
+        {residues != undefined && residues.length > 0 ? (
+          <>
+            <Text className=" mb-2 text-base font-bold text-orange-600">
+              Residuos a cadastrar
+            </Text>
+            <ChosenResiduesInterface residues={residues} />
+          </>
+        ) : (
+          <>
+            <Text className=" mb-2 text-base font-bold text-orange-600">
+              Residuo a cadastrar
+            </Text>
+            <ChosenResidueCard />
+          </>
+        )}
       </View>
 
       {hasRegisteredAddresses && (

--- a/components/custom/AddressInterface/RegisteredAddresses/RegisteredAddressCard/RegisterdAddressCard.tsx
+++ b/components/custom/AddressInterface/RegisteredAddresses/RegisteredAddressCard/RegisterdAddressCard.tsx
@@ -1,12 +1,6 @@
 import React, { FC } from "react";
 import { Text, Pressable } from "react-native";
-import { Address } from "../../types";
-
-interface RegisteredAddressCardProps {
-  item: Address;
-  onSelect: (id: string) => void;
-  selected: boolean;
-}
+import { RegisteredAddressCardProps } from "./types";
 
 const RegisteredAddressCard: FC<RegisteredAddressCardProps> = ({
   item,

--- a/components/custom/AddressInterface/RegisteredAddresses/RegisteredAddressCard/RegisterdAddressCard.tsx
+++ b/components/custom/AddressInterface/RegisteredAddresses/RegisteredAddressCard/RegisterdAddressCard.tsx
@@ -16,17 +16,17 @@ const RegisteredAddressCard: FC<RegisteredAddressCardProps> = ({
   return (
     <Pressable
       onPress={() => onSelect(item._id)}
-      className={`mb-3 p-4 rounded-xl shadow ${
-        selected ? "bg-green-100 border border-green-500" : "bg-white"
+      className={`mb-3 p-4 rounded-sm shadow mt-2 bg-white ${
+        selected ? "bg-green-100 border border-orange-500" : ""
       }`}
     >
-      <Text className="font-medium">
+      <Text className="font-medium text-slate-800">
         {item.street}, {item.number}
       </Text>
-      <Text className="text-sm text-gray-600">
+      <Text className="text-sm text-slate-600">
         {item.neighborhood}, {item.city} - {item.state}
       </Text>
-      <Text className="text-xs text-gray-400">CEP: {item.postalCode}</Text>
+      <Text className="text-xs text-slate-400">CEP: {item.postalCode}</Text>
     </Pressable>
   );
 };

--- a/components/custom/AddressInterface/RegisteredAddresses/RegisteredAddressCard/types/index.ts
+++ b/components/custom/AddressInterface/RegisteredAddresses/RegisteredAddressCard/types/index.ts
@@ -1,0 +1,8 @@
+import { Address } from "../../../types";
+
+interface RegisteredAddressCardProps {
+  item: Address;
+  onSelect: (id: string) => void;
+  selected: boolean;
+}
+export { RegisteredAddressCardProps };

--- a/components/custom/AddressInterface/RegisteredAddresses/RegisteredAdresses.tsx
+++ b/components/custom/AddressInterface/RegisteredAddresses/RegisteredAdresses.tsx
@@ -47,11 +47,6 @@ const RegisteredAddresses = () => {
 
   return (
     <ScrollView contentContainerStyle={{ padding: 6 }}>
-      <Text className="text-lg font-bold mb-2">Endereços Cadastrados</Text>
-      <Text className="text-sm text-gray-600 mb-4">
-        Aqui estão os endereços que você cadastrou.
-      </Text>
-
       {error && <Text className="text-red-500 mb-4">{error}</Text>}
 
       {loading ? (

--- a/components/custom/BackToHomeButton/BackToHomeButton.tsx
+++ b/components/custom/BackToHomeButton/BackToHomeButton.tsx
@@ -2,7 +2,7 @@ import React, { FC } from "react";
 import { useRouter } from "expo-router";
 import { Pressable, View } from "react-native";
 import { HomeIcon } from "lucide-react-native";
-import { User } from "@/app/Home";
+import { User } from "@/types";
 
 interface BackToHomeButtonProps {
   user: User | null;

--- a/components/custom/BackToHomeButton/BackToHomeButton.tsx
+++ b/components/custom/BackToHomeButton/BackToHomeButton.tsx
@@ -2,11 +2,7 @@ import React, { FC } from "react";
 import { useRouter } from "expo-router";
 import { Pressable, View } from "react-native";
 import { HomeIcon } from "lucide-react-native";
-import { User } from "@/types";
-
-interface BackToHomeButtonProps {
-  user: User | null;
-}
+import { BackToHomeButtonProps } from "@/components/types";
 
 const BackToHomeButton: FC<BackToHomeButtonProps> = ({ user }) => {
   const router = useRouter();

--- a/components/custom/CreateCollectModal/CreateCollectModal.tsx
+++ b/components/custom/CreateCollectModal/CreateCollectModal.tsx
@@ -18,11 +18,7 @@ import { useResidue } from "@/hooks/useResidue";
 import { useAddress } from "@/hooks/useAddress";
 import { useCollectEvent } from "@/hooks/useCollectHookEvent";
 import { useCollectFlow } from "@/context/CollectFlowContext";
-
-interface ResidueModalFlowProps {
-  visible: boolean;
-  onClose: () => void;
-}
+import { ResidueModalFlowProps } from "@/components/types";
 
 const ResidueModalFlow: React.FC<ResidueModalFlowProps> = ({
   visible,

--- a/components/custom/CreateCollectModal/CreateCollectModal.tsx
+++ b/components/custom/CreateCollectModal/CreateCollectModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import {
   Modal,
   View,
@@ -29,17 +29,28 @@ const ResidueModalFlow: React.FC<ResidueModalFlowProps> = ({
   onClose,
 }) => {
   const [step, setStep] = useState<1 | 2>(1);
-  const { isResidueValid, payloadResidue } = useResidue();
+  const {
+    isResidueValid,
+    payloadResidue,
+    payloadResiduesArray,
+    isResiduesValid,
+  } = useResidue();
   const { isAddressValid } = useAddress();
   const { handleSubmit, loading } = useCollectEvent();
-  const { previousRegisteredAddressSelectedId } = useCollectFlow();
+  const { resetCollectFlow, previousRegisteredAddressSelectedId, residues } =
+    useCollectFlow();
   const handleClose = () => {
     setStep(1);
     onClose();
+    resetCollectFlow();
   };
 
   const handleNext = async () => {
-    if (step === 1 && isResidueValid) setStep(2);
+    if (
+      (step === 1 && isResidueValid) ||
+      (step === 1 && isResiduesValid(residues))
+    )
+      setStep(2);
   };
 
   const handleBack = () => {
@@ -48,7 +59,12 @@ const ResidueModalFlow: React.FC<ResidueModalFlowProps> = ({
 
   const canSubmit = isAddressValid || !!previousRegisteredAddressSelectedId;
 
-  console.log("Residue Payload", payloadResidue);
+  useEffect(() => {
+    console.log("is Residues Valid", isResiduesValid(residues));
+  }, [residues]);
+
+  console.log("Single Residue Payload", payloadResidue);
+  console.log("Residues Payload Array", payloadResiduesArray);
 
   return (
     <Modal
@@ -86,6 +102,7 @@ const ResidueModalFlow: React.FC<ResidueModalFlowProps> = ({
               <ScrollView
                 className="flex-1"
                 keyboardShouldPersistTaps="handled"
+                nestedScrollEnabled={true}
                 showsVerticalScrollIndicator={false}
               >
                 {step === 1 ? (
@@ -106,15 +123,31 @@ const ResidueModalFlow: React.FC<ResidueModalFlowProps> = ({
                   </TouchableOpacity>
                 )}
                 {step === 1 && (
-                  <TouchableOpacity
-                    onPress={handleNext}
-                    className={`px-4 py-2 rounded-lg ${
-                      isResidueValid ? "bg-green-500" : "bg-gray-300"
-                    }`}
-                    disabled={!isResidueValid}
-                  >
-                    <Text className="text-white">Continuar</Text>
-                  </TouchableOpacity>
+                  <>
+                    {residues && residues.length > 0 ? (
+                      <TouchableOpacity
+                        onPress={handleNext}
+                        className={`px-4 py-2 rounded-lg ${
+                          isResiduesValid(residues)
+                            ? "bg-green-500"
+                            : "bg-gray-300"
+                        }`}
+                        disabled={!isResiduesValid}
+                      >
+                        <Text className="text-white">Continuar</Text>
+                      </TouchableOpacity>
+                    ) : (
+                      <TouchableOpacity
+                        onPress={handleNext}
+                        className={`px-4 py-2 rounded-lg ${
+                          isResidueValid ? "bg-green-500" : "bg-gray-300"
+                        }`}
+                        disabled={!isResidueValid}
+                      >
+                        <Text className="text-white">Continuar</Text>
+                      </TouchableOpacity>
+                    )}
+                  </>
                 )}
                 {step === 2 && (
                   <TouchableOpacity

--- a/components/custom/CreateCollectModal/CreateCollectModal.tsx
+++ b/components/custom/CreateCollectModal/CreateCollectModal.tsx
@@ -29,6 +29,7 @@ const ResidueModalFlow: React.FC<ResidueModalFlowProps> = ({
   onClose,
 }) => {
   const [step, setStep] = useState<1 | 2>(1);
+  const [isMultipleResidues, setIsMultipleResidues] = useState<boolean>(false);
   const {
     isResidueValid,
     payloadResidue,
@@ -54,7 +55,10 @@ const ResidueModalFlow: React.FC<ResidueModalFlowProps> = ({
   };
 
   const handleBack = () => {
-    if (step === 2) setStep(1);
+    if (residues != undefined && residues.length > 0) {
+      setStep(1);
+      setIsMultipleResidues(!isMultipleResidues);
+    } else if (step === 2) setStep(1);
   };
 
   const canSubmit = isAddressValid || !!previousRegisteredAddressSelectedId;
@@ -106,7 +110,9 @@ const ResidueModalFlow: React.FC<ResidueModalFlowProps> = ({
                 showsVerticalScrollIndicator={false}
               >
                 {step === 1 ? (
-                  <WasteManagementInterface />
+                  <WasteManagementInterface
+                    isReturnToMultipleResidues={isMultipleResidues}
+                  />
                 ) : (
                   <AddressInterface />
                 )}

--- a/components/custom/CreateCollectModal/CreateCollectModal.tsx
+++ b/components/custom/CreateCollectModal/CreateCollectModal.tsx
@@ -46,8 +46,16 @@ const ResidueModalFlow: React.FC<ResidueModalFlowProps> = ({
     if (
       (step === 1 && isResidueValid) ||
       (step === 1 && isResiduesValid(residues))
-    )
+    ) {
       setStep(2);
+    } else if (
+      step === 1 &&
+      isResiduesValid(residues) &&
+      residues != undefined &&
+      residues.length >= 2
+    ) {
+      setStep(2);
+    }
   };
 
   const handleBack = () => {
@@ -59,12 +67,16 @@ const ResidueModalFlow: React.FC<ResidueModalFlowProps> = ({
 
   const canSubmit = isAddressValid || !!previousRegisteredAddressSelectedId;
 
-  useEffect(() => {
-    console.log("is Residues Valid", isResiduesValid(residues));
-  }, [residues]);
+  const residuesValid = isResiduesValid(residues);
+  const residuesCount = residues?.length ?? 0;
+  const isConfirmDisabled = !(residuesValid && residuesCount >= 2);
 
-  console.log("Single Residue Payload", payloadResidue);
-  console.log("Residues Payload Array", payloadResiduesArray);
+  console.log(
+    "isResidueConfirmDisabled",
+    isConfirmDisabled,
+
+    !isResiduesValid
+  );
 
   return (
     <Modal
@@ -130,11 +142,9 @@ const ResidueModalFlow: React.FC<ResidueModalFlowProps> = ({
                       <TouchableOpacity
                         onPress={handleNext}
                         className={`px-4 py-2 rounded-lg ${
-                          isResiduesValid(residues)
-                            ? "bg-green-500"
-                            : "bg-gray-300"
+                          !isConfirmDisabled ? "bg-green-500" : "bg-gray-300"
                         }`}
-                        disabled={!isResiduesValid}
+                        disabled={isConfirmDisabled}
                       >
                         <Text className="text-white">Continuar</Text>
                       </TouchableOpacity>

--- a/components/custom/GearButton/GearButton.tsx
+++ b/components/custom/GearButton/GearButton.tsx
@@ -1,13 +1,7 @@
-import { Settings } from "lucide-react-native";
 import React, { FC } from "react";
+import { GearButtonProps } from "@/components/types";
+import { Settings } from "lucide-react-native";
 import { TouchableOpacity } from "react-native";
-
-interface GearButtonProps {
-  setShowActions: (showActions: boolean) => void;
-  showActions: boolean;
-  isProducesWaste: boolean;
-  isCollectsWaste: boolean;
-}
 
 const GearButton: FC<GearButtonProps> = ({
   setShowActions,

--- a/components/custom/InterfaceSwitch/InterfaceSwitch.tsx
+++ b/components/custom/InterfaceSwitch/InterfaceSwitch.tsx
@@ -1,14 +1,6 @@
-import React, { ReactNode } from "react";
+import React from "react";
 import { Pressable, View, Text, StyleSheet } from "react-native";
-
-interface InterfaceSwitchProps {
-  rightLabel: string;
-  leftLabel: string;
-  rightComponent: ReactNode;
-  leftComponent: ReactNode;
-  value: boolean; // Controlled value
-  onToggleChange?: (value: boolean) => void;
-}
+import { InterfaceSwitchProps } from "@/components/types";
 
 const InterfaceSwitch: React.FC<InterfaceSwitchProps> = ({
   rightLabel,

--- a/components/custom/RegionPriceTable/RegionPriceTable.tsx
+++ b/components/custom/RegionPriceTable/RegionPriceTable.tsx
@@ -1,11 +1,7 @@
 import React from "react";
 import { usePriceTable } from "@/hooks/usePriceTable";
 import { View, Text, ActivityIndicator, ScrollView } from "react-native";
-
-type RegionPriceTableProps = {
-  token: string | undefined | null;
-  region: string;
-};
+import { RegionPriceTableProps } from "@/components/types";
 
 export const RegionPriceTable: React.FC<RegionPriceTableProps> = ({
   token,

--- a/components/custom/RegionPriceTable/RegionPriceTable.tsx
+++ b/components/custom/RegionPriceTable/RegionPriceTable.tsx
@@ -1,0 +1,97 @@
+import React, { useEffect, useState } from "react";
+import { View, Text, ActivityIndicator, ScrollView } from "react-native";
+
+type Variant = {
+  label: string;
+  pricePerKg: number;
+  minWeightKg: number;
+  commission30Percent: number;
+};
+
+type PriceTable = {
+  [category: string]: {
+    variants: Variant[];
+  };
+};
+
+type RegionPriceTableProps = {
+  token: string | undefined | null;
+  region: string;
+};
+
+export const RegionPriceTable: React.FC<RegionPriceTableProps> = ({
+  token,
+  region,
+}) => {
+  const [data, setData] = useState<PriceTable | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    const fetchPriceTable = async () => {
+      try {
+        const res = await fetch(
+          `http://192.168.96.2:5000/api/price-tables/${region}`,
+          {
+            headers: {
+              Authorization: `Bearer ${token}`,
+            },
+          }
+        );
+        console.log("Fetching price table for region:", region);
+        console.log("Response status:", res.status);
+        if (!res.ok) {
+          throw new Error("Erro ao carregar tabela de preço.");
+        }
+        const json = await res.json();
+        setData(json);
+      } catch (err: any) {
+        setError(err.message || "Erro desconhecido");
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    if (token) fetchPriceTable();
+  }, [token, region]);
+
+  console.log("Price table data:", data);
+  if (loading) {
+    return (
+      <View className="items-center justify-center h-48">
+        <ActivityIndicator size="large" />
+        <Text className="mt-2">Carregando tabela de preços...</Text>
+      </View>
+    );
+  }
+
+  if (error || !data) {
+    return (
+      <View className="p-4">
+        <Text className="text-red-500 font-semibold">
+          {error || "Não foi possível carregar os dados."}
+        </Text>
+      </View>
+    );
+  }
+
+  return (
+    <ScrollView className="p-4">
+      {Object.entries(data).map(([category, { variants }]) => (
+        <View key={category} className="mb-6">
+          <Text className="text-lg font-bold mb-2">{category}</Text>
+          {variants.map((v, idx) => (
+            <View key={idx} className="mb-2 p-2 border border-zinc-300 rounded">
+              <Text className="font-semibold">{v.label}</Text>
+              <Text>Preço/kg: R$ {v.pricePerKg.toFixed(2)}</Text>
+              <Text>Peso mínimo: {v.minWeightKg}kg</Text>
+              <Text>Comissão (30%): R$ {v.commission30Percent.toFixed(2)}</Text>
+            </View>
+          ))}
+        </View>
+      ))}
+    </ScrollView>
+  );
+};
+
+export default RegionPriceTable;

--- a/components/custom/RegionPriceTable/index.ts
+++ b/components/custom/RegionPriceTable/index.ts
@@ -1,0 +1,1 @@
+export { default as RegionPriceTable } from "./RegionPriceTable";

--- a/components/custom/UserInterface/UserInterface.tsx
+++ b/components/custom/UserInterface/UserInterface.tsx
@@ -1,10 +1,10 @@
-import { User } from "@/app/Home";
 import React, { FC } from "react";
 import { ScrollView, View } from "react-native";
 import { UserActionsInterface } from "./components/UserActionsInterface";
 import { UserArea } from "./components/UserArea";
 import { UserCenter } from "./components/UserCenter";
 import { WasteProducerProvider } from "@/context/WasteProducerContext";
+import { User } from "@/types";
 
 interface UserInterfaceProps {
   user: User;

--- a/components/custom/UserInterface/UserInterface.tsx
+++ b/components/custom/UserInterface/UserInterface.tsx
@@ -4,12 +4,7 @@ import { UserActionsInterface } from "./components/UserActionsInterface";
 import { UserArea } from "./components/UserArea";
 import { UserCenter } from "./components/UserCenter";
 import { WasteProducerProvider } from "@/context/WasteProducerContext";
-import { User } from "@/types";
-
-interface UserInterfaceProps {
-  user: User;
-  onLogout: (() => Promise<any>) | undefined;
-}
+import { UserInterfaceProps } from "@/components/types";
 
 const UserInterface: FC<UserInterfaceProps> = ({ user, onLogout }) => {
   return (

--- a/components/custom/UserInterface/components/CalendarInterface/CalendarInterface.tsx
+++ b/components/custom/UserInterface/components/CalendarInterface/CalendarInterface.tsx
@@ -2,7 +2,7 @@ import React, { FC } from "react";
 import { Calendar } from "./components/Calendar";
 import { Text, View } from "react-native";
 import { CalendarCheck } from "lucide-react-native";
-import { User } from "@/app/Home";
+import { User } from "@/types";
 
 interface CalendarInterfaceProps {
   user: User | null;

--- a/components/custom/UserInterface/components/CalendarInterface/CalendarInterface.tsx
+++ b/components/custom/UserInterface/components/CalendarInterface/CalendarInterface.tsx
@@ -2,11 +2,7 @@ import React, { FC } from "react";
 import { Calendar } from "./components/Calendar";
 import { Text, View } from "react-native";
 import { CalendarCheck } from "lucide-react-native";
-import { User } from "@/types";
-
-interface CalendarInterfaceProps {
-  user: User | null;
-}
+import { CalendarInterfaceProps } from "../types";
 
 const CalendarInterface: FC<CalendarInterfaceProps> = ({ user }) => {
   const isProducesWaste = user?.userType === "PRODUCES_WASTE";

--- a/components/custom/UserInterface/components/UserActionsInterface/UserActionsInterface.tsx
+++ b/components/custom/UserInterface/components/UserActionsInterface/UserActionsInterface.tsx
@@ -1,13 +1,9 @@
 import React, { useState } from "react";
 import { Text, View } from "react-native";
-import { User } from "@/types";
 import { WasteProducerActions } from "./components/WasteProducerActions";
+import { UserActionsInterfaceProps } from "../types";
 
-interface UserActionsInterfaceProps {
-  user: User;
-}
-
-export const UserActionsInterface = ({ user }: UserActionsInterfaceProps) => {
+const UserActionsInterface = ({ user }: UserActionsInterfaceProps) => {
   const [showModal, setShowModal] = useState(false);
 
   const userType = user.userType;

--- a/components/custom/UserInterface/components/UserActionsInterface/UserActionsInterface.tsx
+++ b/components/custom/UserInterface/components/UserActionsInterface/UserActionsInterface.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import { Text, View } from "react-native";
-import { User } from "@/app/Home";
+import { User } from "@/types";
 import { WasteProducerActions } from "./components/WasteProducerActions";
 
 interface UserActionsInterfaceProps {

--- a/components/custom/UserInterface/components/UserActionsInterface/components/WasteProducerActions/WasteProducerActions.tsx
+++ b/components/custom/UserInterface/components/UserActionsInterface/components/WasteProducerActions/WasteProducerActions.tsx
@@ -2,11 +2,7 @@ import { CreateCollectModal } from "@/components/custom/CreateCollectModal";
 import { CollectFlowProvider } from "@/context/CollectFlowContext";
 import React, { FC } from "react";
 import { ScrollView, Button, View } from "react-native";
-
-interface WasteProducerActionsProps {
-  showModal: boolean;
-  setShowModal: (show: boolean) => void;
-}
+import { WasteProducerActionsProps } from "../../../types";
 
 const WasteProducerActions: FC<WasteProducerActionsProps> = ({
   showModal,

--- a/components/custom/UserInterface/components/UserArea/UserArea.tsx
+++ b/components/custom/UserInterface/components/UserArea/UserArea.tsx
@@ -1,13 +1,9 @@
-import { User } from "@/types";
 import React, { FC } from "react";
 import { View, Text, Button } from "react-native";
 import { UserAreaWasteProducerActions } from "./components/UserAreaWasteProducerActions";
 import { UserAreaWasteCollectorActions } from "./components/UserAreaWasteCollectorActions";
 import { useRouter } from "expo-router";
-
-interface UserAreaProps {
-  user: User;
-}
+import { UserAreaProps } from "../types";
 
 const UserArea: FC<UserAreaProps> = ({ user }) => {
   const router = useRouter();

--- a/components/custom/UserInterface/components/UserArea/UserArea.tsx
+++ b/components/custom/UserInterface/components/UserArea/UserArea.tsx
@@ -1,4 +1,4 @@
-import { User } from "@/app/Home";
+import { User } from "@/types";
 import React, { FC } from "react";
 import { View, Text, Button } from "react-native";
 import { UserAreaWasteProducerActions } from "./components/UserAreaWasteProducerActions";

--- a/components/custom/UserInterface/components/UserArea/UserArea.tsx
+++ b/components/custom/UserInterface/components/UserArea/UserArea.tsx
@@ -1,14 +1,16 @@
 import { User } from "@/app/Home";
 import React, { FC } from "react";
-import { View, Text } from "react-native";
+import { View, Text, Button } from "react-native";
 import { UserAreaWasteProducerActions } from "./components/UserAreaWasteProducerActions";
 import { UserAreaWasteCollectorActions } from "./components/UserAreaWasteCollectorActions";
+import { useRouter } from "expo-router";
 
 interface UserAreaProps {
   user: User;
 }
 
 const UserArea: FC<UserAreaProps> = ({ user }) => {
+  const router = useRouter();
   const isProducesWaste = user.userType === "PRODUCES_WASTE";
   const isCollectsWaste = user.userType === "COLLECTS_WASTE";
 
@@ -38,7 +40,12 @@ const UserArea: FC<UserAreaProps> = ({ user }) => {
             Pronto para organizar seus resíduos e coletas ?
           </Text>
         </View>
-
+        <View className="mb-2">
+          <Button
+            title="VER TABELA DE PREÇOS"
+            onPress={() => router.push("/RegionPriceTableScreen")}
+          />
+        </View>
         {isProducesWaste && <UserAreaWasteProducerActions />}
         {isCollectsWaste && <UserAreaWasteCollectorActions />}
       </View>

--- a/components/custom/UserInterface/components/UserArea/components/UserAreaWasteProducerActions/types/index.ts
+++ b/components/custom/UserInterface/components/UserArea/components/UserAreaWasteProducerActions/types/index.ts
@@ -42,6 +42,9 @@ interface Collect {
     {
       condition: string;
       createdAt: string;
+      estimatedValue: number | null;
+      pricePerKg: number | null;
+      variant: string;
       name: string;
       photo: string | null;
       pkg: string;

--- a/components/custom/UserInterface/components/UserCenter/UserCenter.tsx
+++ b/components/custom/UserInterface/components/UserCenter/UserCenter.tsx
@@ -1,15 +1,10 @@
 import React, { FC, useState } from "react";
 import { View, Text } from "react-native";
-import { User } from "@/types";
 import { WasteProducerCenterInterface } from "./components/WasteProducerCenterInterface";
 import { UseCenterGearMenu } from "./components/UserCenterGearMenu";
 import { UserCenterHeading } from "./components/UserCenterHeading";
 import { WasteProducerProvider } from "@/context/WasteProducerContext";
-
-interface UserCenterProps {
-  user: User;
-  onLogout: (() => Promise<any>) | undefined;
-}
+import { UserCenterProps } from "../types";
 
 const UserCenter: FC<UserCenterProps> = ({ user, onLogout }) => {
   const isProducesWaste = user.userType === "PRODUCES_WASTE";

--- a/components/custom/UserInterface/components/UserCenter/UserCenter.tsx
+++ b/components/custom/UserInterface/components/UserCenter/UserCenter.tsx
@@ -1,6 +1,6 @@
 import React, { FC, useState } from "react";
 import { View, Text } from "react-native";
-import { User } from "@/app/Home";
+import { User } from "@/types";
 import { WasteProducerCenterInterface } from "./components/WasteProducerCenterInterface";
 import { UseCenterGearMenu } from "./components/UserCenterGearMenu";
 import { UserCenterHeading } from "./components/UserCenterHeading";

--- a/components/custom/UserInterface/components/UserCenter/components/UserCenterHeading/UserCenterHeading.tsx
+++ b/components/custom/UserInterface/components/UserCenter/components/UserCenterHeading/UserCenterHeading.tsx
@@ -1,7 +1,6 @@
-import { User } from "@/app/Home";
 import { GearButton } from "@/components/custom/GearButton";
 import React, { FC } from "react";
-import { View, Text, TouchableOpacity } from "react-native";
+import { View, Text } from "react-native";
 
 interface UserCenterHeadingProps {
   isProducesWaste: boolean;

--- a/components/custom/UserInterface/components/UserCenter/components/UserProfile/UserProfile.tsx
+++ b/components/custom/UserInterface/components/UserCenter/components/UserProfile/UserProfile.tsx
@@ -1,7 +1,7 @@
 import React, { FC } from "react";
 import { Text, View } from "react-native";
 import { UserPhoto } from "./components/UserPhoto";
-import { User } from "@/app/Home";
+import { User } from "@/types";
 import { User2Icon } from "lucide-react-native";
 import { UserInfo } from "./components/UserInfo";
 import { UserSettings } from "./components/UserSettings";

--- a/components/custom/UserInterface/components/UserCenter/components/UserProfile/components/UserInfo/UserInfo.tsx
+++ b/components/custom/UserInterface/components/UserCenter/components/UserProfile/components/UserInfo/UserInfo.tsx
@@ -1,4 +1,4 @@
-import { User } from "@/app/Home";
+import { User } from "@/types";
 import React, { FC } from "react";
 import { View, Text } from "react-native";
 

--- a/components/custom/UserInterface/components/UserCenter/components/UserProfile/components/UserPhoto/UserPhoto.tsx
+++ b/components/custom/UserInterface/components/UserCenter/components/UserProfile/components/UserPhoto/UserPhoto.tsx
@@ -1,4 +1,4 @@
-import { User } from "@/app/Home";
+import { User } from "@/types";
 import React, { FC } from "react";
 import { View, Text } from "react-native";
 import { Image } from "@/components/ui/image";

--- a/components/custom/UserInterface/components/UserCenter/components/UserProfile/components/UserSettings/UserSettings.tsx
+++ b/components/custom/UserInterface/components/UserCenter/components/UserProfile/components/UserSettings/UserSettings.tsx
@@ -1,4 +1,4 @@
-import { User } from "@/app/Home";
+import { User } from "@/types";
 import React, { FC } from "react";
 import { Button, Text, View } from "react-native";
 import { useUser } from "@/context/UserContext";

--- a/components/custom/UserInterface/components/UserCenter/components/UserProfile/components/UserSettings/components/EditUserButton/EditUserButton.tsx
+++ b/components/custom/UserInterface/components/UserCenter/components/UserProfile/components/UserSettings/components/EditUserButton/EditUserButton.tsx
@@ -1,7 +1,7 @@
 // components/EditUserButton.tsx
 import React, { FC, useState } from "react";
 import { Button, View } from "react-native";
-import { User } from "@/app/Home";
+import { User } from "@/types";
 import { EditUserModal } from "../EditUserModal";
 
 interface EditUserButtonProps {

--- a/components/custom/UserInterface/components/UserCenter/components/UserProfile/components/UserSettings/components/EditUserModal/EditUserModal.tsx
+++ b/components/custom/UserInterface/components/UserCenter/components/UserProfile/components/UserSettings/components/EditUserModal/EditUserModal.tsx
@@ -1,6 +1,6 @@
 import React, { FC, useState, useRef } from "react";
 import { Modal, View, Text, TextInput, Button, Alert } from "react-native";
-import { User } from "@/app/Home";
+import { User } from "@/types";
 import { BlurView } from "expo-blur";
 import PhoneInput from "react-native-phone-number-input";
 import { CPF, CNPJ } from "@brasil-interface/utils";

--- a/components/custom/UserInterface/components/UserCenter/components/WasteProducerCenterInterface/WasteProducerCenterInterface.tsx
+++ b/components/custom/UserInterface/components/UserCenter/components/WasteProducerCenterInterface/WasteProducerCenterInterface.tsx
@@ -1,7 +1,7 @@
 import React, { FC } from "react";
 import { View } from "react-native";
 import { WasteProducerCenterActiveCollects } from "./components/WasteProducerCenterActiveCollects";
-import { User } from "@/app/Home";
+import { User } from "@/types";
 
 interface WasteProducerCenterInterfaceProps {
   user: User;

--- a/components/custom/UserInterface/components/UserCenter/components/WasteProducerCenterInterface/components/WasteProducerCenterActiveCollects/WasteProducerCenterActiveCollects.tsx
+++ b/components/custom/UserInterface/components/UserCenter/components/WasteProducerCenterInterface/components/WasteProducerCenterActiveCollects/WasteProducerCenterActiveCollects.tsx
@@ -4,7 +4,7 @@ import axios from "axios";
 import { format } from "date-fns";
 import { useAuth } from "@/context/AuthContext"; // adjust to your context path
 import Constants from "expo-constants";
-import { User } from "@/app/Home";
+import { User } from "@/types";
 import { SnailIcon } from "lucide-react-native";
 
 interface WasteProducerCenterActiveCollectsProps {

--- a/components/custom/UserInterface/components/WasteProducerHistoryInterface/WasteProducerHistoryInterface.tsx
+++ b/components/custom/UserInterface/components/WasteProducerHistoryInterface/WasteProducerHistoryInterface.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect } from "react";
 import { FlatList, Text, View } from "react-native";
 
-import { User } from "@/app/Home";
+import { User } from "@/types";
 import { ScheduledCollects } from "./components/ScheduledCollects";
 import { CompleteCollects } from "./components/CompleteCollects";
 import { ExpiredCollects } from "./components/ExpiredCollects";

--- a/components/custom/UserInterface/components/WasteProducerHistoryInterface/WasteProducerHistoryInterface.tsx
+++ b/components/custom/UserInterface/components/WasteProducerHistoryInterface/WasteProducerHistoryInterface.tsx
@@ -1,17 +1,12 @@
 import React, { useEffect } from "react";
 import { FlatList, Text, View } from "react-native";
-
-import { User } from "@/types";
 import { ScheduledCollects } from "./components/ScheduledCollects";
 import { CompleteCollects } from "./components/CompleteCollects";
 import { ExpiredCollects } from "./components/ExpiredCollects";
 import { CanceledCollects } from "./components/CanceledCollects";
 import { useWasteProducer } from "@/context/WasteProducerContext";
 import { Calendar } from "lucide-react-native";
-
-interface WasteProducerHistoryProps {
-  user: User | null;
-}
+import { WasteProducerHistoryProps } from "../types";
 
 const WasteProducerHistoryInterface: React.FC<WasteProducerHistoryProps> = ({
   user,

--- a/components/custom/UserInterface/components/WasteProducerHistoryInterface/components/CanceledCollects/CanceledCollects.tsx
+++ b/components/custom/UserInterface/components/WasteProducerHistoryInterface/components/CanceledCollects/CanceledCollects.tsx
@@ -1,4 +1,3 @@
-import { User } from "@/types";
 import React, { FC, useCallback, useEffect, useRef, useState } from "react";
 import {
   ActivityIndicator,
@@ -10,12 +9,7 @@ import {
 } from "react-native";
 import { HistoryCollectsCard } from "../HistoryCollectsCard";
 import { CalendarX } from "lucide-react-native";
-
-interface CanceledCollectsProps {
-  user: User | null;
-  collects: any[];
-  loading: boolean;
-}
+import { CanceledCollectsProps } from "../types";
 
 const CanceledCollects: FC<CanceledCollectsProps> = ({
   user,

--- a/components/custom/UserInterface/components/WasteProducerHistoryInterface/components/CanceledCollects/CanceledCollects.tsx
+++ b/components/custom/UserInterface/components/WasteProducerHistoryInterface/components/CanceledCollects/CanceledCollects.tsx
@@ -1,4 +1,4 @@
-import { User } from "@/app/Home";
+import { User } from "@/types";
 import React, { FC, useCallback, useEffect, useRef, useState } from "react";
 import {
   ActivityIndicator,

--- a/components/custom/UserInterface/components/WasteProducerHistoryInterface/components/CompleteCollects/CompleteCollects.tsx
+++ b/components/custom/UserInterface/components/WasteProducerHistoryInterface/components/CompleteCollects/CompleteCollects.tsx
@@ -1,4 +1,3 @@
-import { User } from "@/types";
 import React, { FC, useCallback, useEffect, useRef, useState } from "react";
 import {
   ActivityIndicator,
@@ -10,12 +9,7 @@ import {
 } from "react-native";
 import { HistoryCollectsCard } from "../HistoryCollectsCard";
 import { CalendarCheck, Flower } from "lucide-react-native";
-
-interface CompleteCollectsProps {
-  user: User | null;
-  collects: any[];
-  loading: boolean;
-}
+import { CompleteCollectsProps } from "../types";
 
 const CompleteCollects: FC<CompleteCollectsProps> = ({
   user,

--- a/components/custom/UserInterface/components/WasteProducerHistoryInterface/components/CompleteCollects/CompleteCollects.tsx
+++ b/components/custom/UserInterface/components/WasteProducerHistoryInterface/components/CompleteCollects/CompleteCollects.tsx
@@ -1,4 +1,4 @@
-import { User } from "@/app/Home";
+import { User } from "@/types";
 import React, { FC, useCallback, useEffect, useRef, useState } from "react";
 import {
   ActivityIndicator,

--- a/components/custom/UserInterface/components/WasteProducerHistoryInterface/components/ExpiredCollects/ExpiredCollects.tsx
+++ b/components/custom/UserInterface/components/WasteProducerHistoryInterface/components/ExpiredCollects/ExpiredCollects.tsx
@@ -1,4 +1,3 @@
-import { User } from "@/types";
 import React, { FC, useCallback, useEffect, useRef, useState } from "react";
 import {
   ActivityIndicator,
@@ -10,12 +9,7 @@ import {
 } from "react-native";
 import { HistoryCollectsCard } from "../HistoryCollectsCard";
 import { AlarmClock, CalendarClock } from "lucide-react-native";
-
-interface ExpiredCollectsProps {
-  user: User | null;
-  collects: any[];
-  loading: boolean;
-}
+import { ExpiredCollectsProps } from "../types";
 
 const ExpiredCollects: FC<ExpiredCollectsProps> = ({
   user,

--- a/components/custom/UserInterface/components/WasteProducerHistoryInterface/components/ExpiredCollects/ExpiredCollects.tsx
+++ b/components/custom/UserInterface/components/WasteProducerHistoryInterface/components/ExpiredCollects/ExpiredCollects.tsx
@@ -28,7 +28,6 @@ const ExpiredCollects: FC<ExpiredCollectsProps> = ({
   const toggleExpanded = () => {
     setExpanded((prev) => !prev);
   };
-
   useEffect(() => {
     Animated.timing(animatedOpacity, {
       toValue: expanded ? 1 : 0,
@@ -37,7 +36,14 @@ const ExpiredCollects: FC<ExpiredCollectsProps> = ({
     }).start();
   }, [expanded]);
 
-  const iconColor = "#eab308";
+  const isProducesWaste = user?.userType === "PRODUCES_WASTE";
+  const isCollectsWaste = user?.userType === "COLLECTS_WASTE";
+
+  const iconColor = isProducesWaste
+    ? "#eab308"
+    : isCollectsWaste
+    ? "#eab308"
+    : "#000000";
 
   const renderCollectItem = useCallback(({ item }: any) => {
     return <HistoryCollectsCard item={item} />;
@@ -71,32 +77,34 @@ const ExpiredCollects: FC<ExpiredCollectsProps> = ({
         </View>
       </Pressable>
 
-      <Animated.View style={{ overflow: "hidden" }}>
-        {loading ? (
-          <View className="flex-1 justify-center items-center ">
-            <ActivityIndicator size="large" color={iconColor} />
-          </View>
-        ) : expiredCollects.length === 0 ? (
-          <View className="flex-1 justify-center items-center">
-            <View className="flex-col items-center">
-              <AlarmClock size={50} color={iconColor} />
-              <Text className="text-yellow-500 mt-2 text-center font-semibold">
-                Nenhuma coleta expirada ainda.
-              </Text>
+      {expanded && (
+        <Animated.View style={{ overflow: "hidden" }}>
+          {loading ? (
+            <View className="flex-1 justify-center items-center ">
+              <ActivityIndicator size="large" color={iconColor} />
             </View>
-          </View>
-        ) : (
-          <FlatList
-            data={expiredCollects}
-            renderItem={renderCollectItem}
-            keyExtractor={(item) => item._id.toString()}
-            getItemLayout={getItemLayout}
-            showsVerticalScrollIndicator={false}
-            scrollEnabled={false} // Let parent scroll instead
-            contentContainerStyle={{ paddingBottom: 10 }}
-          />
-        )}
-      </Animated.View>
+          ) : expiredCollects.length === 0 ? (
+            <View className="flex-1 justify-center items-center">
+              <View className="flex-col items-center">
+                <AlarmClock size={50} color={iconColor} />
+                <Text className="text-yellow-500 mt-2 text-center font-semibold">
+                  Nenhuma coleta expirada ainda.
+                </Text>
+              </View>
+            </View>
+          ) : (
+            <FlatList
+              data={expiredCollects}
+              renderItem={renderCollectItem}
+              keyExtractor={(item) => item._id.toString()}
+              getItemLayout={getItemLayout}
+              showsVerticalScrollIndicator={false}
+              scrollEnabled={false} // Let parent scroll instead
+              contentContainerStyle={{ paddingBottom: 10 }}
+            />
+          )}
+        </Animated.View>
+      )}
     </View>
   );
 };

--- a/components/custom/UserInterface/components/WasteProducerHistoryInterface/components/ExpiredCollects/ExpiredCollects.tsx
+++ b/components/custom/UserInterface/components/WasteProducerHistoryInterface/components/ExpiredCollects/ExpiredCollects.tsx
@@ -23,17 +23,17 @@ const ExpiredCollects: FC<ExpiredCollectsProps> = ({
   loading,
 }) => {
   const [expanded, setExpanded] = useState(false);
-  const animatedHeight = useRef(new Animated.Value(0)).current;
+  const animatedOpacity = useRef(new Animated.Value(0)).current;
 
   const toggleExpanded = () => {
     setExpanded((prev) => !prev);
   };
 
   useEffect(() => {
-    Animated.timing(animatedHeight, {
+    Animated.timing(animatedOpacity, {
       toValue: expanded ? 1 : 0,
       duration: 200,
-      useNativeDriver: false,
+      useNativeDriver: true,
     }).start();
   }, [expanded]);
 
@@ -92,8 +92,8 @@ const ExpiredCollects: FC<ExpiredCollectsProps> = ({
             keyExtractor={(item) => item._id.toString()}
             getItemLayout={getItemLayout}
             showsVerticalScrollIndicator={false}
+            scrollEnabled={false} // Let parent scroll instead
             contentContainerStyle={{ paddingBottom: 10 }}
-            className="flex-1"
           />
         )}
       </Animated.View>

--- a/components/custom/UserInterface/components/WasteProducerHistoryInterface/components/ExpiredCollects/ExpiredCollects.tsx
+++ b/components/custom/UserInterface/components/WasteProducerHistoryInterface/components/ExpiredCollects/ExpiredCollects.tsx
@@ -1,4 +1,4 @@
-import { User } from "@/app/Home";
+import { User } from "@/types";
 import React, { FC, useCallback, useEffect, useRef, useState } from "react";
 import {
   ActivityIndicator,

--- a/components/custom/UserInterface/components/WasteProducerHistoryInterface/components/HistoryCollectsCard/HistoryCollectsCard.tsx
+++ b/components/custom/UserInterface/components/WasteProducerHistoryInterface/components/HistoryCollectsCard/HistoryCollectsCard.tsx
@@ -1,5 +1,5 @@
 import React, { FC } from "react";
-import { Text, View, Image } from "react-native";
+import { View, Image, Text } from "react-native";
 import { Card } from "@/components/ui/card";
 import { Collect } from "../../../UserArea/components/UserAreaWasteProducerActions/types";
 
@@ -27,11 +27,20 @@ const HistoryCollectsCard: FC<HistoryCollectsCardProps> = ({ item }) => {
     });
   };
 
-  const residue = item.residues[0];
+  const singleResidue = item.residues[0];
   const formattedCreatedAt = formatDate(item.createdAt);
   const formattedCreatedTime = formatTime(item.createdAt);
   const formattedFinalDate = formatDate(item.dateTime);
   const formattedFinalTime = formatTime(item.dateTime);
+  const singleResidueVariant = item.residues[0].variant
+    ? item.residues[0].variant
+    : false;
+  const singleResidueVariantEstimatedValue = item.residues[0].estimatedValue
+    ? item.residues[0].estimatedValue
+    : null;
+  const singleResidueVariantPricePerKg = item.residues[0].pricePerKg
+    ? item.residues[0].pricePerKg
+    : null;
 
   return (
     <Card className="mb-4 p-4 rounded-2xl shadow bg-slate-100">
@@ -48,14 +57,13 @@ const HistoryCollectsCard: FC<HistoryCollectsCardProps> = ({ item }) => {
 
         {item.isSigned && item.signedBy && (
           <Text className="text-sm text-gray-500">
-            Por: {item.signedBy.firstName} ({item.signedBy.email})
+            Por: {item.signedBy.firstName} {item.signedBy.email}
           </Text>
         )}
 
         {item.completedBy && (
           <Text className="text-sm text-gray-500">
-            Coletado por: {item.completedBy.firstName} ({item.completedBy.email}
-            )
+            Coletado por: {item.completedBy.firstName} {item.completedBy.email}
           </Text>
         )}
 
@@ -72,15 +80,39 @@ const HistoryCollectsCard: FC<HistoryCollectsCardProps> = ({ item }) => {
 
       <View className="mb-3">
         <Text className="font-semibold text-gray-700 mb-1">Resíduo</Text>
-        <Text className="text-sm text-gray-500">Nome: {residue.name}</Text>
-        <Text className="text-sm text-gray-500">Peso: {residue.weight} kg</Text>
-        <Text className="text-sm text-gray-500">Embalagem: {residue.pkg}</Text>
         <Text className="text-sm text-gray-500">
-          Condição: {residue.condition}
+          Nome: {singleResidue.name}
         </Text>
-        {residue.photo && (
+        {singleResidueVariant && (
+          <Text className="text-sm text-gray-500">
+            Tipo: {singleResidue.variant}
+          </Text>
+        )}
+        <Text className="text-sm text-gray-500">
+          Peso: {singleResidue.weight} kg
+        </Text>
+        {singleResidueVariantEstimatedValue && (
+          <Text className="text-sm text-gray-500">
+            Preço total: R$ {singleResidue.estimatedValue?.toFixed(2) ?? "0.00"}
+          </Text>
+        )}
+        {singleResidueVariantPricePerKg && (
+          <Text className="text-sm text-gray-500">
+            Preço por kg: R${" "}
+            {singleResidue.pricePerKg != null
+              ? singleResidue.pricePerKg.toFixed(2)
+              : "0.00"}
+          </Text>
+        )}
+        <Text className="text-sm text-gray-500">
+          Embalagem: {singleResidue.pkg}
+        </Text>
+        <Text className="text-sm text-gray-500">
+          Condição: {singleResidue.condition}
+        </Text>
+        {singleResidue.photo && (
           <Image
-            source={{ uri: residue.photo }}
+            source={{ uri: singleResidue.photo }}
             style={{
               width: "100%",
               height: 150,

--- a/components/custom/UserInterface/components/WasteProducerHistoryInterface/components/HistoryCollectsCard/HistoryCollectsCard.tsx
+++ b/components/custom/UserInterface/components/WasteProducerHistoryInterface/components/HistoryCollectsCard/HistoryCollectsCard.tsx
@@ -1,11 +1,7 @@
 import React, { FC } from "react";
 import { View, Image, Text } from "react-native";
 import { Card } from "@/components/ui/card";
-import { Collect } from "../../../UserArea/components/UserAreaWasteProducerActions/types";
-
-interface HistoryCollectsCardProps {
-  item: Collect;
-}
+import { HistoryCollectsCardProps } from "../types";
 
 const HistoryCollectsCard: FC<HistoryCollectsCardProps> = ({ item }) => {
   if (!item.residues?.[0] || !item.address) return null;

--- a/components/custom/UserInterface/components/WasteProducerHistoryInterface/components/ScheduledCollects/ScheduledCollects.tsx
+++ b/components/custom/UserInterface/components/WasteProducerHistoryInterface/components/ScheduledCollects/ScheduledCollects.tsx
@@ -1,4 +1,4 @@
-import { User } from "@/app/Home";
+import { User } from "@/types";
 import { Calendar1, CalendarClock } from "lucide-react-native";
 import React, { FC, useState, useRef, useEffect, useCallback } from "react";
 import {

--- a/components/custom/UserInterface/components/WasteProducerHistoryInterface/components/ScheduledCollects/ScheduledCollects.tsx
+++ b/components/custom/UserInterface/components/WasteProducerHistoryInterface/components/ScheduledCollects/ScheduledCollects.tsx
@@ -1,4 +1,3 @@
-import { User } from "@/types";
 import { Calendar1, CalendarClock } from "lucide-react-native";
 import React, { FC, useState, useRef, useEffect, useCallback } from "react";
 import {
@@ -10,12 +9,7 @@ import {
   FlatList,
 } from "react-native";
 import { HistoryCollectsCard } from "../HistoryCollectsCard";
-
-interface ScheduledCollectsProps {
-  user: User | null;
-  collects: any[];
-  loading: boolean;
-}
+import { ScheduledCollectsProps } from "../types";
 
 const ScheduledCollects: FC<ScheduledCollectsProps> = ({
   user,

--- a/components/custom/UserInterface/components/WasteProducerHistoryInterface/components/types/index.ts
+++ b/components/custom/UserInterface/components/WasteProducerHistoryInterface/components/types/index.ts
@@ -1,0 +1,38 @@
+import { User } from "@/types";
+import { Collect } from "../../../UserArea/components/UserAreaWasteProducerActions/types";
+
+interface CanceledCollectsProps {
+  user: User | null;
+  collects: any[];
+  loading: boolean;
+}
+
+interface CompleteCollectsProps {
+  user: User | null;
+  collects: any[];
+  loading: boolean;
+}
+
+interface ExpiredCollectsProps {
+  user: User | null;
+  collects: any[];
+  loading: boolean;
+}
+
+interface HistoryCollectsCardProps {
+  item: Collect;
+}
+
+interface ScheduledCollectsProps {
+  user: User | null;
+  collects: any[];
+  loading: boolean;
+}
+
+export {
+  CanceledCollectsProps,
+  CompleteCollectsProps,
+  ExpiredCollectsProps,
+  HistoryCollectsCardProps,
+  ScheduledCollectsProps,
+};

--- a/components/custom/UserInterface/components/WasteProducerStatsInterface/WasteProducerStatsInterface.tsx
+++ b/components/custom/UserInterface/components/WasteProducerStatsInterface/WasteProducerStatsInterface.tsx
@@ -1,29 +1,18 @@
 import React, { FC, useEffect } from "react";
 import { ScrollView, Text, View } from "react-native";
-import { User } from "@/types";
 import { ChartColumn } from "lucide-react-native";
 import { ResiduesSection } from "./components/ResiduesSection";
 import { CollectsSection } from "./components/CollectsSection";
-
 import {
   EventDetail,
   useWasteProducerStats,
 } from "@/context/WasteProducerStatsContext";
 import { CollectStats } from "./components/CollectsSection/CollectsSection";
 import { AccountSection } from "./components/AccountSection";
-
-interface WasteProducerStatsInterfaceProps {
-  user: User | null;
-}
-
-interface ResidueStatsByStatus {
-  [status: string]: {
-    [name: string]: {
-      count: number;
-      totalQuantity: number;
-    };
-  };
-}
+import {
+  ResidueStatsByStatus,
+  WasteProducerStatsInterfaceProps,
+} from "../types";
 
 const WasteProducerStatsInterface: FC<WasteProducerStatsInterfaceProps> = ({
   user,

--- a/components/custom/UserInterface/components/WasteProducerStatsInterface/WasteProducerStatsInterface.tsx
+++ b/components/custom/UserInterface/components/WasteProducerStatsInterface/WasteProducerStatsInterface.tsx
@@ -1,6 +1,6 @@
 import React, { FC, useEffect } from "react";
 import { ScrollView, Text, View } from "react-native";
-import { User } from "@/app/Home";
+import { User } from "@/types";
 import { ChartColumn } from "lucide-react-native";
 import { ResiduesSection } from "./components/ResiduesSection";
 import { CollectsSection } from "./components/CollectsSection";

--- a/components/custom/UserInterface/components/WasteProducerStatsInterface/components/AccountSection/AccountSection.tsx
+++ b/components/custom/UserInterface/components/WasteProducerStatsInterface/components/AccountSection/AccountSection.tsx
@@ -10,13 +10,7 @@ import {
 } from "lucide-react-native";
 import { BarChart } from "react-native-gifted-charts";
 import { EventDetail } from "@/context/WasteProducerStatsContext";
-import { User } from "@/types";
-
-interface AccountSectionProps {
-  user: User | null;
-  loading: boolean;
-  events: EventDetail[];
-}
+import { AccountSectionProps } from "../types";
 
 export const AccountSection: FC<AccountSectionProps> = ({
   user,

--- a/components/custom/UserInterface/components/WasteProducerStatsInterface/components/AccountSection/AccountSection.tsx
+++ b/components/custom/UserInterface/components/WasteProducerStatsInterface/components/AccountSection/AccountSection.tsx
@@ -5,14 +5,12 @@ import {
   BarChart3,
   CheckCircle2,
   Recycle,
-  ChevronDown,
-  ChevronUp,
   Clock3,
   ChartNoAxesColumn,
 } from "lucide-react-native";
 import { BarChart } from "react-native-gifted-charts";
 import { EventDetail } from "@/context/WasteProducerStatsContext";
-import { User } from "@/app/Home";
+import { User } from "@/types";
 
 interface AccountSectionProps {
   user: User | null;

--- a/components/custom/UserInterface/components/WasteProducerStatsInterface/components/CollectsSection/CollectsSection.tsx
+++ b/components/custom/UserInterface/components/WasteProducerStatsInterface/components/CollectsSection/CollectsSection.tsx
@@ -9,7 +9,7 @@ import {
 } from "react-native";
 import { BarChart } from "react-native-gifted-charts";
 import { ArchiveIcon } from "lucide-react-native";
-import { User } from "@/app/Home";
+import { User } from "@/types";
 
 export interface CollectStats {
   status: string;

--- a/components/custom/UserInterface/components/WasteProducerStatsInterface/components/CollectsSection/CollectsSection.tsx
+++ b/components/custom/UserInterface/components/WasteProducerStatsInterface/components/CollectsSection/CollectsSection.tsx
@@ -9,7 +9,7 @@ import {
 } from "react-native";
 import { BarChart } from "react-native-gifted-charts";
 import { ArchiveIcon } from "lucide-react-native";
-import { User } from "@/types";
+import { CollectsSectionProps } from "../types";
 
 export interface CollectStats {
   status: string;
@@ -20,12 +20,6 @@ export interface CollectStats {
   canceledRate: number;
   scheduled: number;
   completed: number;
-}
-
-interface CollectsSectionProps {
-  user: User | null;
-  loading: boolean;
-  collectStats: CollectStats[];
 }
 
 const CollectsSection: FC<CollectsSectionProps> = ({

--- a/components/custom/UserInterface/components/WasteProducerStatsInterface/components/ResiduesSection/ResiduesSection.tsx
+++ b/components/custom/UserInterface/components/WasteProducerStatsInterface/components/ResiduesSection/ResiduesSection.tsx
@@ -10,35 +10,11 @@ import {
 import { Picker } from "@react-native-picker/picker";
 import { BarChart } from "react-native-gifted-charts";
 import { Gem } from "lucide-react-native";
-import { User } from "@/types";
-
-interface Residue {
-  name: string;
-  totalQuantity: number;
-  count: number;
-}
-
-interface ResidueStatsByStatus {
-  [status: string]: {
-    [name: string]: {
-      count: number;
-      totalQuantity: number;
-    };
-  };
-}
-
-interface ResiduesSectionProps {
-  user: User | null;
-  loading: boolean;
-  residueStatsPerStatus: ResidueStatsByStatus;
-  summary: {
-    completed: number;
-    expired: number;
-    scheduled: number;
-    canceled: number;
-    total: number;
-  };
-}
+import {
+  ResiduesSectionProps,
+  ResidueStatsByStatus,
+  StatsResidue,
+} from "../types";
 
 const statusLabels: Record<string, string> = {
   completed: "Coletas Concluídas",
@@ -113,7 +89,7 @@ const ResiduesSection: FC<ResiduesSectionProps> = ({
       ? { [selectedStatus]: residueStatsPerStatus[selectedStatus] || {} }
       : {};
 
-  const allResidues: Residue[] = Object.entries(residuesMap).flatMap(
+  const allResidues: StatsResidue[] = Object.entries(residuesMap).flatMap(
     ([status, residues]) =>
       Object.entries(residues).map(([name, stats]) => ({
         name:

--- a/components/custom/UserInterface/components/WasteProducerStatsInterface/components/ResiduesSection/ResiduesSection.tsx
+++ b/components/custom/UserInterface/components/WasteProducerStatsInterface/components/ResiduesSection/ResiduesSection.tsx
@@ -10,7 +10,7 @@ import {
 import { Picker } from "@react-native-picker/picker";
 import { BarChart } from "react-native-gifted-charts";
 import { Gem } from "lucide-react-native";
-import { User } from "@/app/Home";
+import { User } from "@/types";
 
 interface Residue {
   name: string;

--- a/components/custom/UserInterface/components/WasteProducerStatsInterface/components/types/index.ts
+++ b/components/custom/UserInterface/components/WasteProducerStatsInterface/components/types/index.ts
@@ -1,0 +1,62 @@
+import { EventDetail } from "@/context/WasteProducerStatsContext";
+import { User } from "@/types";
+
+interface AccountSectionProps {
+  user: User | null;
+  loading: boolean;
+  events: EventDetail[];
+}
+
+interface CollectStats {
+  status: string;
+  count: number;
+  avgQuantity: number;
+  successRate: number;
+  expiredRate: number;
+  canceledRate: number;
+  scheduled: number;
+  completed: number;
+}
+
+interface CollectsSectionProps {
+  user: User | null;
+  loading: boolean;
+  collectStats: CollectStats[];
+}
+
+interface StatsResidue {
+  name: string;
+  totalQuantity: number;
+  count: number;
+}
+
+interface ResidueStatsByStatus {
+  [status: string]: {
+    [name: string]: {
+      count: number;
+      totalQuantity: number;
+    };
+  };
+}
+
+interface ResiduesSectionProps {
+  user: User | null;
+  loading: boolean;
+  residueStatsPerStatus: ResidueStatsByStatus;
+  summary: {
+    completed: number;
+    expired: number;
+    scheduled: number;
+    canceled: number;
+    total: number;
+  };
+}
+
+export {
+  AccountSectionProps,
+  CollectsSectionProps,
+  CollectStats,
+  StatsResidue,
+  ResidueStatsByStatus,
+  ResiduesSectionProps,
+};

--- a/components/custom/UserInterface/components/types/index.ts
+++ b/components/custom/UserInterface/components/types/index.ts
@@ -1,0 +1,51 @@
+import { User } from "@/types";
+
+interface CalendarInterfaceProps {
+  user: User | null;
+}
+
+interface WasteProducerHistoryProps {
+  user: User | null;
+}
+
+interface UserActionsInterfaceProps {
+  user: User;
+}
+
+interface UserAreaProps {
+  user: User;
+}
+
+interface WasteProducerActionsProps {
+  showModal: boolean;
+  setShowModal: (show: boolean) => void;
+}
+
+interface UserCenterProps {
+  user: User;
+  onLogout: (() => Promise<any>) | undefined;
+}
+
+interface WasteProducerStatsInterfaceProps {
+  user: User | null;
+}
+
+interface ResidueStatsByStatus {
+  [status: string]: {
+    [name: string]: {
+      count: number;
+      totalQuantity: number;
+    };
+  };
+}
+
+export {
+  WasteProducerStatsInterfaceProps,
+  ResidueStatsByStatus,
+  WasteProducerHistoryProps,
+  UserCenterProps,
+  UserAreaProps,
+  CalendarInterfaceProps,
+  UserActionsInterfaceProps,
+  WasteProducerActionsProps,
+};

--- a/components/custom/UserTypePicker/UserTypePicker.tsx
+++ b/components/custom/UserTypePicker/UserTypePicker.tsx
@@ -1,23 +1,12 @@
 import React, { useState } from "react";
-import {
-  View,
-  TouchableOpacity,
-  Modal,
-  Text as RNText,
-  Button,
-} from "react-native";
-import { Text } from "@/components/ui/text"; // assuming you have a custom Text component
 import { GoogleUserWelcome } from "./components/GoogleUserWelcome";
 import { AddPersonalInfo } from "./components/AddPersonalInfo";
 import { useUser } from "@/context/UserContext";
 import { UserTypePickerInterface } from "./components/UserTypePickerInterface";
 import { UserTypeConfirmModal } from "./components/UserTypeConfirmModal";
+import { UserTypePickerProps } from "@/components/types";
 
-type Props = {
-  onSelect: (userType: "COLLECTS_WASTE" | "PRODUCES_WASTE") => void;
-};
-
-const UserTypePicker = ({ onSelect }: Props) => {
+const UserTypePicker = ({ onSelect }: UserTypePickerProps) => {
   const { updateUser, user } = useUser();
   const [isModalVisible, setIsModalVisible] = useState(false);
   const [selectedUserType, setSelectedUserType] = useState<

--- a/components/custom/UserTypePicker/components/AddPersonalInfo/AddPersonalInfo.tsx
+++ b/components/custom/UserTypePicker/components/AddPersonalInfo/AddPersonalInfo.tsx
@@ -1,14 +1,9 @@
-import { User } from "@/types";
 import React, { FC, useRef, useState } from "react";
 import { View, Text, Alert, TextInput, Button } from "react-native";
 import { CPF, CNPJ } from "@brasil-interface/utils";
 import PhoneInput from "react-native-phone-number-input";
 import { CheckCircle } from "lucide-react-native";
-
-interface AddPersonalInfoProps {
-  updateUser: (data: Partial<User>) => Promise<void>;
-  user: User | null;
-}
+import { AddPersonalInfoProps } from "../types";
 
 const AddPersonalInfo: FC<AddPersonalInfoProps> = ({ updateUser, user }) => {
   const phoneInputRef = useRef<PhoneInput>(null);

--- a/components/custom/UserTypePicker/components/AddPersonalInfo/AddPersonalInfo.tsx
+++ b/components/custom/UserTypePicker/components/AddPersonalInfo/AddPersonalInfo.tsx
@@ -1,4 +1,4 @@
-import { User } from "@/app/Home";
+import { User } from "@/types";
 import React, { FC, useRef, useState } from "react";
 import { View, Text, Alert, TextInput, Button } from "react-native";
 import { CPF, CNPJ } from "@brasil-interface/utils";

--- a/components/custom/UserTypePicker/components/GoogleUserWelcome/GoogleUserWelcome.tsx
+++ b/components/custom/UserTypePicker/components/GoogleUserWelcome/GoogleUserWelcome.tsx
@@ -1,11 +1,7 @@
-import { User } from "@/types";
-import { UserPhoto } from "@/components/custom/UserInterface/components/UserCenter/components/UserProfile/components/UserPhoto";
 import React, { FC } from "react";
+import { UserPhoto } from "@/components/custom/UserInterface/components/UserCenter/components/UserProfile/components/UserPhoto";
 import { View, Text } from "react-native";
-
-interface GoogleUserWelcomeProps {
-  user: User | null;
-}
+import { GoogleUserWelcomeProps } from "../types";
 
 const GoogleUserWelcome: FC<GoogleUserWelcomeProps> = ({ user }) => {
   return (

--- a/components/custom/UserTypePicker/components/GoogleUserWelcome/GoogleUserWelcome.tsx
+++ b/components/custom/UserTypePicker/components/GoogleUserWelcome/GoogleUserWelcome.tsx
@@ -1,4 +1,4 @@
-import { User } from "@/app/Home";
+import { User } from "@/types";
 import { UserPhoto } from "@/components/custom/UserInterface/components/UserCenter/components/UserProfile/components/UserPhoto";
 import React, { FC } from "react";
 import { View, Text } from "react-native";

--- a/components/custom/UserTypePicker/components/UserTypeConfirmModal/UserTypeConfirmModal.tsx
+++ b/components/custom/UserTypePicker/components/UserTypeConfirmModal/UserTypeConfirmModal.tsx
@@ -1,12 +1,7 @@
 import { BlurView } from "expo-blur";
 import React, { FC } from "react";
 import { Button, Modal, Text, View } from "react-native";
-
-interface UserTypeConfirmModalProps {
-  isModalVisible: boolean;
-  handleConfirm: () => void;
-  handleCancel: () => void;
-}
+import { UserTypeConfirmModalProps } from "../types";
 
 const UserTypeConfirmModal: FC<UserTypeConfirmModalProps> = ({
   isModalVisible,

--- a/components/custom/UserTypePicker/components/UserTypePickerInterface/UserTypePickerInterface.tsx
+++ b/components/custom/UserTypePicker/components/UserTypePickerInterface/UserTypePickerInterface.tsx
@@ -1,13 +1,10 @@
 import React, { FC } from "react";
 import { Text, TouchableOpacity, View } from "react-native";
+import { GoogleUserTypePickerProps } from "../types";
 
-interface UserTypePickerProps {
-  handleSelect: (userType: "COLLECTS_WASTE" | "PRODUCES_WASTE") => void;
-  handleConfirm: () => void;
-  handleCancel: () => void;
-}
-
-const UserTypePickerInterface: FC<UserTypePickerProps> = ({ handleSelect }) => {
+const UserTypePickerInterface: FC<GoogleUserTypePickerProps> = ({
+  handleSelect,
+}) => {
   return (
     <View className="p-6 bg-white rounded shadow-lg w-full">
       <Text className="text-lg font-semibold mb-6 text-slate-800 uppercase">

--- a/components/custom/UserTypePicker/components/types/index.ts
+++ b/components/custom/UserTypePicker/components/types/index.ts
@@ -1,0 +1,29 @@
+import { User } from "@/types";
+
+interface AddPersonalInfoProps {
+  updateUser: (data: Partial<User>) => Promise<void>;
+  user: User | null;
+}
+
+interface GoogleUserWelcomeProps {
+  user: User | null;
+}
+
+interface UserTypeConfirmModalProps {
+  isModalVisible: boolean;
+  handleConfirm: () => void;
+  handleCancel: () => void;
+}
+
+interface GoogleUserTypePickerProps {
+  handleSelect: (userType: "COLLECTS_WASTE" | "PRODUCES_WASTE") => void;
+  handleConfirm: () => void;
+  handleCancel: () => void;
+}
+
+export {
+  AddPersonalInfoProps,
+  GoogleUserWelcomeProps,
+  GoogleUserTypePickerProps,
+  UserTypeConfirmModalProps,
+};

--- a/components/custom/WasteManagementInterface/AvailableDate/AvailableDate.tsx
+++ b/components/custom/WasteManagementInterface/AvailableDate/AvailableDate.tsx
@@ -1,7 +1,6 @@
 import React, { FC, useState } from "react";
 import { View, Platform, TouchableOpacity, Text } from "react-native";
 import DateTimePicker from "@react-native-community/datetimepicker";
-import { Heading } from "@/components/ui/heading";
 import { Calendar } from "lucide-react-native";
 import { format } from "date-fns";
 import { ptBR } from "date-fns/locale";
@@ -21,9 +20,9 @@ const AvailableDate: FC<AvailableDateProps> = () => {
 
   return (
     <View className={`${Platform.OS !== "windows" ? "mt-6" : ""}`}>
-      <Heading size="xs" className="mb-2">
+      <Text className="text-md font-bold mb-2 text-orange-600">
         Data Preferida para Coleta
-      </Heading>
+      </Text>
 
       <TouchableOpacity
         className="flex-row items-center bg-white"

--- a/components/custom/WasteManagementInterface/PackageAvailableSelector/PackageAvailableSelector.tsx
+++ b/components/custom/WasteManagementInterface/PackageAvailableSelector/PackageAvailableSelector.tsx
@@ -1,4 +1,4 @@
-import { Heading } from "@/components/ui/heading";
+import React from "react";
 import { CircleIcon } from "@/components/ui/icon";
 import {
   Radio,
@@ -8,8 +8,7 @@ import {
   RadioLabel,
 } from "@/components/ui/radio";
 import { VStack } from "@/components/ui/vstack";
-import React from "react";
-import { Platform, View } from "react-native";
+import { Text, View } from "react-native";
 import { PackageAvailableSelectorProps } from "../types";
 import { PACKAGE_OPTIONS } from "../utils/enum";
 
@@ -18,8 +17,10 @@ const PackageAvailableSelector: React.FC<PackageAvailableSelectorProps> = ({
   setSelectedPackage,
 }) => {
   return (
-    <View className={`${Platform.OS === "android" ? "mt-6" : ""}`}>
-      <Heading size="xs">Embalagem Disponível</Heading>
+    <View className="mt-4">
+      <Text className="text-md font-bold  text-orange-600">
+        Embalagem Disponível
+      </Text>
       <RadioGroup
         className="mt-2"
         value={selectedPackage}
@@ -27,8 +28,8 @@ const PackageAvailableSelector: React.FC<PackageAvailableSelectorProps> = ({
       >
         <VStack space="sm">
           {PACKAGE_OPTIONS.map((option) => (
-            <Radio key={option} value={option}>
-              <RadioIndicator className="border-zinc-300 rounded-md">
+            <Radio key={option} value={option} className="border-orange-600">
+              <RadioIndicator className="border-orange-300 rounded-md">
                 <RadioIcon as={CircleIcon} />
               </RadioIndicator>
               <RadioLabel>{option}</RadioLabel>

--- a/components/custom/WasteManagementInterface/QuantityInput/QuantityInput.tsx
+++ b/components/custom/WasteManagementInterface/QuantityInput/QuantityInput.tsx
@@ -3,7 +3,11 @@ import { View, StyleSheet, TextInput, Text } from "react-native";
 import { QuantityInputProps } from "../types";
 import { WeightIcon } from "lucide-react-native";
 
-const QuantityInput: React.FC<QuantityInputProps> = ({ weight, setWeight }) => {
+const QuantityInput: React.FC<QuantityInputProps> = ({
+  weight,
+  setWeight,
+  inputBackgroundColor,
+}) => {
   const handleChange = (text: string) => {
     // Only allow numbers and a single dot (for decimal values)
     if (/^\d*\.?\d*$/.test(text) || text === "") {
@@ -12,15 +16,20 @@ const QuantityInput: React.FC<QuantityInputProps> = ({ weight, setWeight }) => {
   };
 
   return (
-    <View className="flex-1">
-      <Text className="text-md font-bold mb-2 mt-4 text-slate-800">
-        Quantidade em Kg
+    <View>
+      <Text className="text-md font-bold mb-2 mt-2 text-orange-600">
+        Peso (kg)
       </Text>
       <View>
-        <View style={styles.inputWrapper}>
-          <WeightIcon size={18} color="#9CA3AF" style={styles.icon} />
+        <View
+          className={`flex flex-row items-center w-full  rounded-lg  py-2 px-1`}
+          style={{ backgroundColor: inputBackgroundColor || "#F3F4F6" }}
+        >
+          <View className="mr-1 ml-1">
+            <WeightIcon size={18} color="#9CA3AF" />
+          </View>
           <TextInput
-            style={styles.input}
+            className="text-sm text-slate-800"
             placeholder="Ex: 123.45"
             value={weight}
             onChangeText={handleChange}
@@ -32,22 +41,4 @@ const QuantityInput: React.FC<QuantityInputProps> = ({ weight, setWeight }) => {
     </View>
   );
 };
-const styles = StyleSheet.create({
-  inputWrapper: {
-    flexDirection: "row",
-    alignItems: "center",
-    width: "100%",
-    backgroundColor: "#F3F4F6", // light gray background
-    borderRadius: 8,
-    paddingHorizontal: 12,
-    paddingVertical: 6,
-  },
-  icon: {
-    marginRight: 4,
-  },
-  input: {
-    fontSize: 13,
-    color: "#111827",
-  },
-});
 export default QuantityInput;

--- a/components/custom/WasteManagementInterface/ResidueConditionSelector/ResidueConditionSelector.tsx
+++ b/components/custom/WasteManagementInterface/ResidueConditionSelector/ResidueConditionSelector.tsx
@@ -1,4 +1,4 @@
-import { Heading } from "@/components/ui/heading";
+import React from "react";
 import { CircleIcon } from "@/components/ui/icon";
 import {
   Radio,
@@ -8,8 +8,7 @@ import {
   RadioLabel,
 } from "@/components/ui/radio";
 import { VStack } from "@/components/ui/vstack";
-import React from "react";
-import { Platform, View } from "react-native";
+import { Text, View } from "react-native";
 import { ResidueConditionSelectorProps } from "../types";
 import { RESIDUE_CONDITIONS } from "../utils/enum";
 
@@ -18,8 +17,10 @@ const ResidueConditionSelector: React.FC<ResidueConditionSelectorProps> = ({
   setSelectedCondition,
 }) => {
   return (
-    <View className={`${Platform.OS != "windows" ? "mt-6" : ""}`}>
-      <Heading size="xs">Condição do Resído</Heading>
+    <View className="mt-4">
+      <Text className="text-md font-bold text-orange-600">
+        Condição do Resído
+      </Text>
       <RadioGroup
         className="mt-2"
         value={selectedCondition}
@@ -28,7 +29,7 @@ const ResidueConditionSelector: React.FC<ResidueConditionSelectorProps> = ({
         <VStack space="sm">
           {RESIDUE_CONDITIONS.map((condition) => (
             <Radio key={condition} value={condition}>
-              <RadioIndicator className="border-zinc-300">
+              <RadioIndicator className="border-orange-300">
                 <RadioIcon as={CircleIcon} />
               </RadioIndicator>
               <RadioLabel>{condition}</RadioLabel>

--- a/components/custom/WasteManagementInterface/ResidueVariantSelector/ResidueVariantSelector.tsx
+++ b/components/custom/WasteManagementInterface/ResidueVariantSelector/ResidueVariantSelector.tsx
@@ -1,0 +1,40 @@
+import React from "react";
+import { View, Text, TouchableOpacity } from "react-native";
+import { FC } from "react";
+import { ResidueVariant } from "../types";
+
+type ResidueVariantSelectorProps = {
+  variants: ResidueVariant[];
+  selectedVariant: ResidueVariant | null;
+  setSelectedVariant: (variant: ResidueVariant) => void;
+};
+
+const ResidueVariantSelector: FC<ResidueVariantSelectorProps> = ({
+  variants,
+  selectedVariant,
+  setSelectedVariant,
+}) => {
+  return (
+    <View className="mt-4">
+      <Text className="mb-2 font-semibold">Tipo específico</Text>
+      {variants.map((variant, idx) => (
+        <TouchableOpacity
+          key={idx}
+          onPress={() => setSelectedVariant(variant)}
+          className={`p-3 rounded-md mb-2 border ${
+            selectedVariant?.label === variant.label
+              ? "border-blue-500 bg-blue-100"
+              : "border-gray-300"
+          }`}
+        >
+          <Text className="text-base font-medium">{variant.label}</Text>
+          <Text className="text-xs text-gray-500">
+            R$ {variant.pricePerKg}/kg • Mín: {variant.minWeightKg}kg
+          </Text>
+        </TouchableOpacity>
+      ))}
+    </View>
+  );
+};
+
+export default ResidueVariantSelector;

--- a/components/custom/WasteManagementInterface/ResidueVariantSelector/index.ts
+++ b/components/custom/WasteManagementInterface/ResidueVariantSelector/index.ts
@@ -1,0 +1,1 @@
+export { default as ResidueVariantSelector } from "./ResidueVariantSelector";

--- a/components/custom/WasteManagementInterface/ScheduleHour/ScheduleHour.tsx
+++ b/components/custom/WasteManagementInterface/ScheduleHour/ScheduleHour.tsx
@@ -102,9 +102,9 @@ const ScheduleHour: FC<ScheduleHourProps> = ({
 
   return (
     <View className={`${Platform.OS !== "windows" ? "mt-6" : ""}`}>
-      <Heading size="xs" className="mb-2">
+      <Text className="text-md font-bold mb-2  text-orange-600">
         Hora Preferida para Coleta
-      </Heading>
+      </Text>
 
       <TouchableOpacity
         className="flex-row items-center bg-white"

--- a/components/custom/WasteManagementInterface/SelectableResidueIcons/MultipleResidueSelector/MultipleResidueSelector.tsx
+++ b/components/custom/WasteManagementInterface/SelectableResidueIcons/MultipleResidueSelector/MultipleResidueSelector.tsx
@@ -56,14 +56,16 @@ const MultipleResidueSelector: React.FC<ResidueAndVariantsSelectorProps> = ({
     if (setResidues) {
       setResidues([...(residues ?? []), newResidue]);
     }
-
+    setWeight("");
     setResidue(null);
     setVariant(null);
   };
 
-  const handleRemove = (name: string) => {
+  const handleRemove = (variantLabel: string | undefined) => {
     if (setResidues) {
-      setResidues((residues ?? []).filter((r) => r.name !== name));
+      setResidues(
+        (residues ?? []).filter((r) => r.variant?.label !== variantLabel)
+      );
     }
   };
 

--- a/components/custom/WasteManagementInterface/SelectableResidueIcons/MultipleResidueSelector/MultipleResidueSelector.tsx
+++ b/components/custom/WasteManagementInterface/SelectableResidueIcons/MultipleResidueSelector/MultipleResidueSelector.tsx
@@ -1,0 +1,112 @@
+import React from "react";
+import { View, Alert } from "react-native";
+import {
+  Residue,
+  ResidueAndVariantsSelectorProps,
+  ResidueVariant,
+} from "../../types";
+import { useCollectFlow } from "@/context/CollectFlowContext";
+import { SavedResiduesSection } from "./components/SavedResiduesSection";
+import { WasteManagementHeadingSection } from "../../WasteManagementHeadingSection";
+import { MultipleResiduesAndVariantsSection } from "./components/MultipleResiduesAndVariantsSection";
+const MultipleResidueSelector: React.FC<ResidueAndVariantsSelectorProps> = ({
+  photo,
+  variants,
+  weight,
+  selectedResidue,
+  selectedVariant,
+  selectedCondition,
+  selectedPackage,
+  setCondition,
+  setPhoto,
+  setPackage,
+  setResidue,
+  setResidues,
+  setVariant,
+  setWeight,
+}) => {
+  const { residues } = useCollectFlow();
+
+  const handleSave = () => {
+    if (!selectedResidue || !selectedVariant) {
+      Alert.alert(
+        "Erro",
+        "Preencha o peso e selecione uma variante (se aplicável)"
+      );
+      return;
+    }
+
+    if ((residues?.length ?? 0) >= 10) {
+      Alert.alert("Limite atingido", "Máximo de 10 resíduos permitidos.");
+      return;
+    }
+
+    // Use the selected variant (passed via props) instead of mapping all variants
+    const newResidue: Residue = {
+      ...selectedResidue,
+      id: selectedResidue.id,
+      photo: photo,
+      alt: selectedResidue.alt,
+      variant: selectedVariant,
+      weight: parseFloat(weight),
+      condition: selectedCondition || "Nenhuma condição",
+      pkg: selectedPackage || "Nenhuma embalagem",
+    };
+
+    if (setResidues) {
+      setResidues([...(residues ?? []), newResidue]);
+    }
+
+    setResidue(null);
+    setVariant(null);
+  };
+
+  const handleRemove = (name: string) => {
+    if (setResidues) {
+      setResidues((residues ?? []).filter((r) => r.name !== name));
+    }
+  };
+
+  console.log("Residues:", residues);
+
+  const calculatePrice = (variant: ResidueVariant | null, weight: string) => {
+    if (!variant || !weight) return "0.00";
+    const weightNum = parseFloat(weight);
+    if (isNaN(weightNum) || weightNum <= 0) return "0.00";
+    return (variant.pricePerKg * weightNum).toFixed(2);
+  };
+
+  const title = "Detalhes dos Resíduos para Descarte";
+  const description =
+    "Escolha até 10 resíduos por coleta. Selecione o(s) resíduo(s) desejado(s) e preencha os detalhes necessários para agendar a coleta.";
+
+  return (
+    <View className="pt-4">
+      <WasteManagementHeadingSection title={title} description={description} />
+
+      <MultipleResiduesAndVariantsSection
+        photo={photo}
+        variants={variants}
+        weight={weight}
+        selectedResidue={selectedResidue}
+        selectedVariant={selectedVariant}
+        selectedCondition={selectedCondition}
+        selectedPackage={selectedPackage}
+        setPhoto={setPhoto}
+        setWeight={setWeight}
+        setCondition={setCondition}
+        setPackage={setPackage}
+        setResidue={setResidue}
+        setVariant={setVariant}
+        handleSave={handleSave}
+      />
+      <SavedResiduesSection
+        residues={residues}
+        handleRemove={handleRemove}
+        calculatePrice={calculatePrice}
+      />
+    </View>
+  );
+};
+
+export default MultipleResidueSelector;

--- a/components/custom/WasteManagementInterface/SelectableResidueIcons/MultipleResidueSelector/components/MultipleResiduesAndVariantsSection/MultipleResiduesAndVariantsSection.tsx
+++ b/components/custom/WasteManagementInterface/SelectableResidueIcons/MultipleResidueSelector/components/MultipleResiduesAndVariantsSection/MultipleResiduesAndVariantsSection.tsx
@@ -1,0 +1,187 @@
+import React from "react";
+import { View, TouchableOpacity, Text } from "react-native";
+import Animated, { FadeIn, FadeOut, Layout } from "react-native-reanimated";
+import { PackageAvailableSelector } from "@/components/custom/WasteManagementInterface/PackageAvailableSelector";
+import { QuantityInput } from "@/components/custom/WasteManagementInterface/QuantityInput";
+import { ResidueConditionSelector } from "@/components/custom/WasteManagementInterface/ResidueConditionSelector";
+import { TakeResiduePhoto } from "@/components/custom/WasteManagementInterface/TakeResiduePhoto";
+import {
+  Residue,
+  ResidueVariant,
+} from "@/components/custom/WasteManagementInterface/types";
+import { RESIDUE_CARDS } from "@/components/custom/WasteManagementInterface/utils/enum";
+import { Card } from "@/components/ui/card";
+import { Image } from "@/components/ui/image";
+
+type MultipleResiduesAndVariantsSectionProps = {
+  handleSave: () => void;
+  selectedResidue: Residue | null;
+  variants: ResidueVariant[];
+  photo: string | null;
+  weight: string;
+  selectedCondition: string;
+  selectedPackage: string;
+  selectedVariant: ResidueVariant | null;
+  setPhoto: (photo: string | null) => void;
+  setResidue: (residue: Residue | null) => void;
+  setPackage: (pkg: string) => void;
+  setCondition: (condition: string) => void;
+  setVariant: (variant: ResidueVariant | null) => void;
+  setWeight: (w: string) => void;
+};
+
+const MultipleResiduesAndVariantsSection: React.FC<
+  MultipleResiduesAndVariantsSectionProps
+> = ({
+  handleSave,
+  selectedResidue,
+  variants,
+  photo,
+  weight,
+  selectedCondition,
+  selectedPackage,
+  selectedVariant,
+  setPhoto,
+  setResidue,
+  setPackage,
+  setCondition,
+  setVariant,
+  setWeight,
+}) => {
+  return (
+    <>
+      <Text className="mt-2 mb-2 text-base font-bold text-orange-600">
+        Escolha Seus Resíduos
+      </Text>
+
+      {!selectedResidue && (
+        <Animated.View
+          entering={FadeIn.duration(200)}
+          exiting={FadeOut.duration(200)}
+          layout={Layout.springify()}
+          style={{ flexDirection: "row", flexWrap: "wrap", gap: 8 }}
+        >
+          {RESIDUE_CARDS.map((card) => (
+            <TouchableOpacity
+              key={card.apiName}
+              onPress={() => setResidue(card)}
+              style={{ marginBottom: 8, flexBasis: "48%" }}
+            >
+              <Card className="flex flex-row items-center rounded-sm  w-full bg-orange-100 shadow ">
+                <Image
+                  source={{ uri: card.image }}
+                  size="xs"
+                  alt={`Imagem de ${card.alt}`}
+                  className="h-12"
+                />
+                <View className="mx-auto">
+                  <Text className="text-orange-600 font-bold">{card.name}</Text>
+                </View>
+              </Card>
+            </TouchableOpacity>
+          ))}
+        </Animated.View>
+      )}
+
+      {selectedResidue && (
+        <Animated.View
+          entering={FadeIn.duration(200)}
+          exiting={FadeOut.duration(200)}
+          layout={Layout.springify()}
+        >
+          <TouchableOpacity onPress={() => setResidue(null)}>
+            <View className="flex flex-row">
+              <View className="-mt-1 mr-1">
+                <Text style={{ color: "#f97316", marginBottom: 8 }}>←</Text>
+              </View>
+              <View>
+                <Text style={{ color: "#f97316", marginBottom: 8 }}>
+                  Voltar
+                </Text>
+              </View>
+            </View>
+          </TouchableOpacity>
+
+          <Card className="flex flex-row items-center border border-orange-500 w-full rounded-sm">
+            <View className=" mx-auto">
+              <Text className="font-bold text-orange-500">
+                {selectedResidue.name}
+              </Text>
+            </View>
+          </Card>
+
+          <Card
+            style={{
+              borderColor: "#f97316",
+              backgroundColor: "#ffedd5",
+              padding: 10,
+              borderTopLeftRadius: 0,
+              borderTopRightRadius: 0,
+            }}
+          >
+            {variants.length > 0 && (
+              <View className="mt-2">
+                {variants.map((variant, idx) => (
+                  <TouchableOpacity
+                    key={idx}
+                    onPress={() => setVariant(variant)}
+                    className={`p-3 mb-2 shadow rounded-sm bg-white ${
+                      selectedVariant?.label === variant.label
+                        ? "border border-orange-500 "
+                        : "border-gray-300"
+                    }`}
+                  >
+                    <Text className="text-base font-medium">
+                      {variant.label}
+                    </Text>
+                    <Text className="text-xs text-gray-500">
+                      R$ {variant.pricePerKg}/kg • Mín: {variant.minWeightKg}
+                      kg
+                    </Text>
+                  </TouchableOpacity>
+                ))}
+              </View>
+            )}
+            <View className="space-y-6">
+              <QuantityInput
+                weight={weight}
+                setWeight={setWeight}
+                inputBackgroundColor="#FFFFFF"
+              />
+              <ResidueConditionSelector
+                selectedCondition={selectedCondition}
+                setSelectedCondition={setCondition}
+              />
+              <PackageAvailableSelector
+                selectedPackage={selectedPackage}
+                setSelectedPackage={setPackage}
+              />
+              <TakeResiduePhoto photo={photo || null} setPhoto={setPhoto} />
+            </View>
+
+            <TouchableOpacity
+              onPress={handleSave}
+              style={{
+                marginTop: 16,
+                backgroundColor: "#16a34a",
+                borderRadius: 6,
+                paddingVertical: 12,
+              }}
+            >
+              <Text
+                style={{
+                  color: "white",
+                  fontWeight: "600",
+                  textAlign: "center",
+                }}
+              >
+                Salvar Resíduo
+              </Text>
+            </TouchableOpacity>
+          </Card>
+        </Animated.View>
+      )}
+    </>
+  );
+};
+export default MultipleResiduesAndVariantsSection;

--- a/components/custom/WasteManagementInterface/SelectableResidueIcons/MultipleResidueSelector/components/MultipleResiduesAndVariantsSection/MultipleResiduesAndVariantsSection.tsx
+++ b/components/custom/WasteManagementInterface/SelectableResidueIcons/MultipleResidueSelector/components/MultipleResiduesAndVariantsSection/MultipleResiduesAndVariantsSection.tsx
@@ -5,33 +5,13 @@ import { PackageAvailableSelector } from "@/components/custom/WasteManagementInt
 import { QuantityInput } from "@/components/custom/WasteManagementInterface/QuantityInput";
 import { ResidueConditionSelector } from "@/components/custom/WasteManagementInterface/ResidueConditionSelector";
 import { TakeResiduePhoto } from "@/components/custom/WasteManagementInterface/TakeResiduePhoto";
-import {
-  Residue,
-  ResidueVariant,
-} from "@/components/custom/WasteManagementInterface/types";
+import { ResidueAndVariantsSelectorProps } from "@/components/custom/WasteManagementInterface/types";
 import { RESIDUE_CARDS } from "@/components/custom/WasteManagementInterface/utils/enum";
 import { Card } from "@/components/ui/card";
 import { Image } from "@/components/ui/image";
 
-type MultipleResiduesAndVariantsSectionProps = {
-  handleSave: () => void;
-  selectedResidue: Residue | null;
-  variants: ResidueVariant[];
-  photo: string | null;
-  weight: string;
-  selectedCondition: string;
-  selectedPackage: string;
-  selectedVariant: ResidueVariant | null;
-  setPhoto: (photo: string | null) => void;
-  setResidue: (residue: Residue | null) => void;
-  setPackage: (pkg: string) => void;
-  setCondition: (condition: string) => void;
-  setVariant: (variant: ResidueVariant | null) => void;
-  setWeight: (w: string) => void;
-};
-
 const MultipleResiduesAndVariantsSection: React.FC<
-  MultipleResiduesAndVariantsSectionProps
+  ResidueAndVariantsSelectorProps
 > = ({
   handleSave,
   selectedResidue,

--- a/components/custom/WasteManagementInterface/SelectableResidueIcons/MultipleResidueSelector/components/MultipleResiduesAndVariantsSection/MultipleResiduesAndVariantsSection.tsx
+++ b/components/custom/WasteManagementInterface/SelectableResidueIcons/MultipleResidueSelector/components/MultipleResiduesAndVariantsSection/MultipleResiduesAndVariantsSection.tsx
@@ -136,7 +136,7 @@ const MultipleResiduesAndVariantsSection: React.FC<
                 selectedPackage={selectedPackage}
                 setSelectedPackage={setPackage}
               />
-              <TakeResiduePhoto photo={photo || null} setPhoto={setPhoto} />
+              {/*<TakeResiduePhoto photo={photo || null} setPhoto={setPhoto} />*/}
             </View>
 
             <TouchableOpacity

--- a/components/custom/WasteManagementInterface/SelectableResidueIcons/MultipleResidueSelector/components/MultipleResiduesAndVariantsSection/index.ts
+++ b/components/custom/WasteManagementInterface/SelectableResidueIcons/MultipleResidueSelector/components/MultipleResiduesAndVariantsSection/index.ts
@@ -1,0 +1,1 @@
+export { default as MultipleResiduesAndVariantsSection } from "./MultipleResiduesAndVariantsSection";

--- a/components/custom/WasteManagementInterface/SelectableResidueIcons/MultipleResidueSelector/components/SavedResiduesSection/SavedResiduesSection.tsx
+++ b/components/custom/WasteManagementInterface/SelectableResidueIcons/MultipleResidueSelector/components/SavedResiduesSection/SavedResiduesSection.tsx
@@ -30,7 +30,7 @@ const SavedResiduesSection: React.FC<SavedResiduesSectionProps> = ({
             {residues?.map((r) => (
               <Card
                 className="shadow rounded-none border-l border-orange-500"
-                key={r.apiName}
+                key={r.variant?.label}
                 style={{
                   flexDirection: "row",
                   justifyContent: "space-between",
@@ -101,7 +101,7 @@ const SavedResiduesSection: React.FC<SavedResiduesSectionProps> = ({
                 </View>
                 <TouchableOpacity
                   className="absolute top-1 right-1"
-                  onPress={() => handleRemove(r.name)}
+                  onPress={() => handleRemove(r.variant?.label)}
                 >
                   <XIcon size={18} color="red" style={{ marginLeft: 8 }} />
                 </TouchableOpacity>

--- a/components/custom/WasteManagementInterface/SelectableResidueIcons/MultipleResidueSelector/components/SavedResiduesSection/SavedResiduesSection.tsx
+++ b/components/custom/WasteManagementInterface/SelectableResidueIcons/MultipleResidueSelector/components/SavedResiduesSection/SavedResiduesSection.tsx
@@ -1,0 +1,116 @@
+import { SavedResiduesSectionProps } from "@/components/custom/WasteManagementInterface/types";
+import { Card } from "@/components/ui/card";
+import { LeafIcon, XIcon } from "lucide-react-native";
+import React from "react";
+import { View, TouchableOpacity, Text, ScrollView } from "react-native";
+
+const SavedResiduesSection: React.FC<SavedResiduesSectionProps> = ({
+  residues,
+  handleRemove,
+  calculatePrice,
+}) => {
+  return (
+    <View className="mt-2 mr-1">
+      <Text className="mb-2 text-base font-bold text-orange-600">
+        Resíduos Selecionados
+      </Text>
+      <ScrollView className="border border-orange-300 rounded-md p-2 min-h-36 max-h-80">
+        {residues?.length === 0 && (
+          <View className="w-full  items-center justify-center">
+            <View className="mt-9">
+              <LeafIcon size={28} color="#fed7aa" />
+            </View>
+            <Text className="font-semibold text-orange-200">
+              Não há resíduos salvos
+            </Text>
+          </View>
+        )}
+        {(residues?.length ?? 0) > 0 && (
+          <>
+            {residues?.map((r) => (
+              <Card
+                className="shadow rounded-none border-l border-orange-500"
+                key={r.apiName}
+                style={{
+                  flexDirection: "row",
+                  justifyContent: "space-between",
+                  alignItems: "center",
+                  marginVertical: 4,
+                  paddingHorizontal: 12,
+                  paddingBottom: 8,
+                  paddingTop: 4,
+                  backgroundColor: "#ffffff",
+                }}
+              >
+                <View>
+                  <View>
+                    <Text className="uppercase text-xs text-orange-600">
+                      {r.name}
+                    </Text>
+                  </View>
+                  <View className="flex flex-row items-center">
+                    <Text className="font-medium text-sm mr-1 text-slate-700">
+                      {r.variant && r.variant.label}
+                    </Text>
+                    <Text className="text-xs text-slate-400 ">
+                      | {r.variant ? `R$ ${r.variant.pricePerKg}/kg` : ""}
+                    </Text>
+                  </View>
+                  <View className="flex flex-row items-center">
+                    <Text className="text-xs  mr-1 text-slate-400">
+                      {r && r.condition}
+                    </Text>
+                    <Text className="text-xs text-slate-400 ">
+                      | {r.variant ? `${r.pkg}` : ""}
+                    </Text>
+                  </View>
+                  <View className="flex flex-row items-center mr-1 mt-1">
+                    <View className="flex flex-row items-center mt-1">
+                      <Text className="text-xs text-slate-400 mr-1">
+                        Quantidade:
+                      </Text>
+                      <Text className="text-md text-slate-600 font-semibold ">
+                        {r.weight}kg
+                      </Text>
+                      <View className="flex flex-row items-center ml-20">
+                        <View>
+                          <Text className="text-xs text-slate-400 mr-1">
+                            Preço:
+                          </Text>
+                        </View>
+                        <View className="flex flex-row items-center">
+                          <View>
+                            <Text className="text-slate-600 text-sm font-semibold">
+                              R${" "}
+                            </Text>
+                          </View>
+                          <Text className="text-lg text-slate-600  -ml-[2px] font-semibold">
+                            {r.variant
+                              ? calculatePrice(
+                                  r.variant,
+                                  r.weight !== undefined
+                                    ? String(r.weight)
+                                    : "0"
+                                )
+                              : "0"}
+                          </Text>
+                        </View>
+                      </View>
+                    </View>
+                  </View>
+                </View>
+                <TouchableOpacity
+                  className="absolute top-1 right-1"
+                  onPress={() => handleRemove(r.name)}
+                >
+                  <XIcon size={18} color="red" style={{ marginLeft: 8 }} />
+                </TouchableOpacity>
+              </Card>
+            ))}
+          </>
+        )}
+      </ScrollView>
+    </View>
+  );
+};
+export default SavedResiduesSection;

--- a/components/custom/WasteManagementInterface/SelectableResidueIcons/MultipleResidueSelector/components/SavedResiduesSection/index.ts
+++ b/components/custom/WasteManagementInterface/SelectableResidueIcons/MultipleResidueSelector/components/SavedResiduesSection/index.ts
@@ -1,0 +1,1 @@
+export { default as SavedResiduesSection } from "./SavedResiduesSection";

--- a/components/custom/WasteManagementInterface/SelectableResidueIcons/MultipleResidueSelector/index.ts
+++ b/components/custom/WasteManagementInterface/SelectableResidueIcons/MultipleResidueSelector/index.ts
@@ -1,0 +1,1 @@
+export { default as MultipleResidueSelector } from "./MultipleResidueSelector";

--- a/components/custom/WasteManagementInterface/SelectableResidueIcons/SelectableResidueIcons.tsx
+++ b/components/custom/WasteManagementInterface/SelectableResidueIcons/SelectableResidueIcons.tsx
@@ -96,12 +96,11 @@ const SelectableResidueIcons: React.FC<SelectableResidueIconsProps> = ({
               <Card className="flex flex-row items-center border w-full border-zinc-300">
                 <Image
                   source={{ uri: card.image }}
-                  width={10}
-                  height={10}
+                  size="xs"
                   alt={`Imagem de ${card.alt}`}
-                  className="h-8"
+                  className="h-12"
                 />
-                <View className="mt-5">
+                <View className="mx-auto">
                   <Text>{card.name}</Text>
                 </View>
               </Card>
@@ -138,12 +137,11 @@ const SelectableResidueIcons: React.FC<SelectableResidueIconsProps> = ({
           <Card className="flex flex-row items-center border border-blue-500 w-full">
             <Image
               source={{ uri: selectedResidue.image }}
-              width={10}
-              height={10}
+              size="xs"
               alt={`Imagem de ${selectedResidue.alt}`}
-              className="h-8"
+              className="h-10"
             />
-            <View className="mt-5">
+            <View className=" mx-auto">
               <Text className="font-bold text-blue-500">
                 {selectedResidue.name}
               </Text>

--- a/components/custom/WasteManagementInterface/SelectableResidueIcons/SelectableResidueIcons.tsx
+++ b/components/custom/WasteManagementInterface/SelectableResidueIcons/SelectableResidueIcons.tsx
@@ -4,20 +4,32 @@ import {
   Platform,
   View,
   Image as RNImage,
+  TouchableOpacity,
 } from "react-native";
 import { Card } from "@/components/ui/card";
 import { Heading } from "@/components/ui/heading";
 import { Image } from "@/components/ui/image";
 import { Text } from "@/components/ui/text";
-import { SelectableResidueIconsProps } from "../types";
+import { SelectableResidueIconsProps, ResidueVariant } from "../types";
 import { RESIDUE_CARDS } from "../utils/enum";
+import { useAuth } from "@/context/AuthContext";
+
+type PriceTable = Record<string, { variants: ResidueVariant[] }>;
 
 const SelectableResidueIcons: React.FC<SelectableResidueIconsProps> = ({
   selectedResidue,
   setSelectedResidue,
+  selectedVariant,
+  setSelectedVariant,
 }) => {
+  const { authState } = useAuth();
   const [loading, setLoading] = useState(true);
+  // priceTable é um objeto: { [apiName: string]: ResidueVariant[] }
+  const [priceTable, setPriceTable] = useState<PriceTable>({});
+  // variants é o array de variantes para o resíduo selecionado
+  const [variants, setVariants] = useState<ResidueVariant[]>([]);
 
+  // Preload das imagens
   useEffect(() => {
     const preloadImages = async () => {
       try {
@@ -35,6 +47,43 @@ const SelectableResidueIcons: React.FC<SelectableResidueIconsProps> = ({
     preloadImages();
   }, []);
 
+  // Busca tabela de preços
+  useEffect(() => {
+    const fetchPriceTable = async () => {
+      try {
+        const res = await fetch(
+          "http://192.168.96.2:5000/api/price-tables/sp",
+          {
+            headers: { Authorization: `Bearer ${authState?.token}` },
+          }
+        );
+        const json = await res.json();
+        // Aqui assumimos que json é do tipo Record<string, ResidueVariant[]>
+        setPriceTable(json);
+      } catch (err) {
+        console.warn("[ResidueIcons] Erro ao buscar tabela de preços:", err);
+      }
+    };
+
+    fetchPriceTable();
+  }, [authState?.token]);
+
+  // Atualiza variantes quando um resíduo é selecionado ou priceTable muda
+  useEffect(() => {
+    if (selectedResidue?.apiName) {
+      // Corrigido para acessar a propriedade .variants
+      const variantsForResidue =
+        priceTable[selectedResidue.apiName]?.variants || [];
+      setVariants(variantsForResidue);
+      if (setSelectedVariant) {
+        setSelectedVariant(null); // limpa seleção anterior
+      }
+    } else {
+      setVariants([]);
+      setSelectedVariant?.(null);
+    }
+  }, [selectedResidue, priceTable, setSelectedVariant]);
+
   if (loading) {
     return (
       <View className="items-center justify-center h-48">
@@ -43,6 +92,13 @@ const SelectableResidueIcons: React.FC<SelectableResidueIconsProps> = ({
       </View>
     );
   }
+
+  console.log("[SelectableResidueIcons] Variants Length:", variants.length);
+  console.log(
+    "[SelectableResidueIcons] Selected Residue:",
+    selectedResidue?.name
+  );
+  console.log("[SelectableResidueIcons] Variants:", variants);
 
   return (
     <View>
@@ -79,6 +135,28 @@ const SelectableResidueIcons: React.FC<SelectableResidueIconsProps> = ({
           );
         })}
       </View>
+
+      {variants.length > 0 && (
+        <View className="mt-4">
+          <Text className="mb-2 font-semibold">Tipo específico</Text>
+          {variants.map((variant, idx) => (
+            <TouchableOpacity
+              key={idx}
+              onPress={() => setSelectedVariant?.(variant)}
+              className={`p-3 rounded-md mb-2 border ${
+                selectedVariant?.label === variant.label
+                  ? "border-blue-500 bg-blue-100"
+                  : "border-gray-300"
+              }`}
+            >
+              <Text className="text-base font-medium">{variant.label}</Text>
+              <Text className="text-xs text-gray-500">
+                R$ {variant.pricePerKg}/kg • Mín: {variant.minWeightKg}kg
+              </Text>
+            </TouchableOpacity>
+          ))}
+        </View>
+      )}
     </View>
   );
 };

--- a/components/custom/WasteManagementInterface/SelectableResidueIcons/SelectableResidueIcons.tsx
+++ b/components/custom/WasteManagementInterface/SelectableResidueIcons/SelectableResidueIcons.tsx
@@ -103,56 +103,82 @@ const SelectableResidueIcons: React.FC<SelectableResidueIconsProps> = ({
   return (
     <View>
       <Heading size="xs">Tipo de Resíduo</Heading>
-      <View className="flex-row flex-wrap justify-between mt-2">
-        {RESIDUE_CARDS.map((card) => {
-          const isSelected = selectedResidue?.id === card.id;
-          return (
-            <Card
-              onTouchStart={() => setSelectedResidue(card)}
-              key={card.id}
-              className={`items-center my-2 border ${
-                Platform.OS === "android" ? "w-[165px]" : "w-[150px]"
-              } ${isSelected ? "border-blue-500" : "border-zinc-300"}`}
-            >
-              <Image
-                source={{ uri: card.image }}
-                style={{
-                  width: "100%",
-                  aspectRatio: 1,
-                  resizeMode: "contain",
-                }}
-                alt={`Imagem de ${card.alt}`}
-                className="h-24"
-              />
-              <View className="mt-5">
-                <Text
-                  className={`${isSelected ? "font-bold text-blue-500" : ""}`}
-                >
-                  {card.name}
-                </Text>
-              </View>
-            </Card>
-          );
-        })}
-      </View>
 
-      {variants.length > 0 && (
-        <View className="mt-4">
-          <Text className="mb-2 font-semibold">Tipo específico</Text>
-          {variants.map((variant, idx) => (
-            <TouchableOpacity
-              key={idx}
-              onPress={() => setSelectedVariant?.(variant)}
-              className={`p-3 rounded-md mb-2 border ${
-                selectedVariant?.label === variant.label
-                  ? "border-blue-500 bg-blue-100"
-                  : "border-gray-300"
-              }`}
-            >
-              <Text className="text-base font-medium">{variant.label}</Text>
-              <Text className="text-xs text-gray-500">
-                R$ {variant.pricePerKg}/kg • Mín: {variant.minWeightKg}kg
+      {selectedResidue ? (
+        <View className="mt-2">
+          {/* Botão para voltar à seleção */}
+          <TouchableOpacity
+            onPress={() => {
+              setSelectedResidue(null as any);
+              setSelectedVariant?.(null);
+            }}
+            className="mb-4"
+          >
+            <Text className="text-blue-500 underline items-center">
+              ← Voltar a seleção de resíduo
+            </Text>
+          </TouchableOpacity>
+
+          {/* Card do resíduo selecionado */}
+          <Card className="flex flex-row items-center border border-blue-500 w-full">
+            <Image
+              source={{ uri: selectedResidue.image }}
+              width={10}
+              height={10}
+              alt={`Imagem de ${selectedResidue.alt}`}
+              className="h-8"
+            />
+            <View className="mt-5">
+              <Text className="font-bold text-blue-500">
+                {selectedResidue.name}
               </Text>
+            </View>
+          </Card>
+
+          {/* Lista de variantes */}
+          {variants.length > 0 && (
+            <View className="mt-4 pl-2">
+              <Text className="mb-2 font-semibold">Tipo específico</Text>
+              {variants.map((variant, idx) => (
+                <TouchableOpacity
+                  key={idx}
+                  onPress={() => setSelectedVariant?.(variant)}
+                  className={`p-3 rounded-md mb-2 border ${
+                    selectedVariant?.label === variant.label
+                      ? "border-blue-500 bg-blue-100"
+                      : "border-gray-300"
+                  }`}
+                >
+                  <Text className="text-base font-medium">{variant.label}</Text>
+                  <Text className="text-xs text-gray-500">
+                    R$ {variant.pricePerKg}/kg • Mín: {variant.minWeightKg}kg
+                  </Text>
+                </TouchableOpacity>
+              ))}
+            </View>
+          )}
+        </View>
+      ) : (
+        // Exibe todos os cards se nenhum estiver selecionado
+        <View className="flex justify-between mt-2 w-full">
+          {RESIDUE_CARDS.map((card) => (
+            <TouchableOpacity
+              key={card.id}
+              onPress={() => setSelectedResidue(card)}
+              className="mb-2"
+            >
+              <Card className="flex flex-row items-center border w-full border-zinc-300">
+                <Image
+                  source={{ uri: card.image }}
+                  width={10}
+                  height={10}
+                  alt={`Imagem de ${card.alt}`}
+                  className="h-8"
+                />
+                <View className="mt-5">
+                  <Text>{card.name}</Text>
+                </View>
+              </Card>
             </TouchableOpacity>
           ))}
         </View>

--- a/components/custom/WasteManagementInterface/SelectableResidueIcons/SelectableResidueIcons.tsx
+++ b/components/custom/WasteManagementInterface/SelectableResidueIcons/SelectableResidueIcons.tsx
@@ -31,7 +31,7 @@ const SelectableResidueIcons: React.FC<SelectableResidueIconsProps> = ({
   setVariant,
 }) => {
   const { authState } = useAuth();
-  const { loading, priceTable } = usePriceTable(authState?.token ?? "");
+  const { loading, priceTable } = usePriceTable(authState?.token ?? "", "sp");
 
   // Preload das imagens dos resíduos
   useEffect(() => {

--- a/components/custom/WasteManagementInterface/SelectableResidueIcons/SelectableResidueIcons.tsx
+++ b/components/custom/WasteManagementInterface/SelectableResidueIcons/SelectableResidueIcons.tsx
@@ -29,6 +29,7 @@ const SelectableResidueIcons: React.FC<SelectableResidueIconsProps> = ({
   setPackage,
   setVariant,
   setResidues,
+  isMultipleResidues,
 }) => {
   const [toggleDefault, setToggleDefault] = useState(false);
   const { authState } = useAuth();
@@ -68,6 +69,8 @@ const SelectableResidueIcons: React.FC<SelectableResidueIconsProps> = ({
     }
   }, [selectedResidue]);
 
+  console.log("isMultipleResidues Selectable Icons ", isMultipleResidues);
+
   const handleSwitchChange = (isToggled: boolean) => {
     setToggleDefault(isToggled); // Update state based on user action
     resetCollectFlow();
@@ -88,7 +91,7 @@ const SelectableResidueIcons: React.FC<SelectableResidueIconsProps> = ({
         leftLabel="Resíduo Único"
         rightLabel="Multiplos Resíduos"
         onToggleChange={handleSwitchChange}
-        value={toggleDefault}
+        value={isMultipleResidues ? !toggleDefault : toggleDefault}
         leftComponent={
           <SingleResidueSelector
             photo={photo}

--- a/components/custom/WasteManagementInterface/SelectableResidueIcons/SingleResidueSelector/SingleResidueSelector.tsx
+++ b/components/custom/WasteManagementInterface/SelectableResidueIcons/SingleResidueSelector/SingleResidueSelector.tsx
@@ -47,7 +47,7 @@ const SingleResidueSelector: React.FC<ResidueAndVariantsSelectorProps> = ({
           selectedPackage={selectedPackage}
           setSelectedPackage={setPackage}
         />
-        <TakeResiduePhoto photo={photo || null} setPhoto={setPhoto} />
+        {/*<TakeResiduePhoto photo={photo || null} setPhoto={setPhoto} />*/}
       </View>
     </View>
   );

--- a/components/custom/WasteManagementInterface/SelectableResidueIcons/SingleResidueSelector/SingleResidueSelector.tsx
+++ b/components/custom/WasteManagementInterface/SelectableResidueIcons/SingleResidueSelector/SingleResidueSelector.tsx
@@ -1,0 +1,55 @@
+import React from "react";
+import { View } from "react-native";
+import { ResidueAndVariantsSelectorProps } from "../../types";
+import { QuantityInput } from "../../QuantityInput";
+import { ResidueConditionSelector } from "../../ResidueConditionSelector";
+import { PackageAvailableSelector } from "../../PackageAvailableSelector";
+import { TakeResiduePhoto } from "../../TakeResiduePhoto";
+import { WasteManagementHeadingSection } from "../../WasteManagementHeadingSection";
+import { SingleResidueAndVariantsSection } from "./components/SingleResidueAndVariantSection";
+
+const SingleResidueSelector: React.FC<ResidueAndVariantsSelectorProps> = ({
+  photo,
+  variants,
+  weight,
+  selectedResidue,
+  selectedVariant,
+  selectedCondition,
+  selectedPackage,
+  setPhoto,
+  setWeight,
+  setCondition,
+  setPackage,
+  setResidue,
+  setVariant,
+}) => {
+  const title = "Detalhe do Resíduo para Descarte";
+  const description =
+    "Escolha o resíduo, condição, quantidade, embalagem e uma data para coleta.";
+
+  return (
+    <View className="pt-4">
+      <WasteManagementHeadingSection title={title} description={description} />
+      <SingleResidueAndVariantsSection
+        selectedResidue={selectedResidue}
+        setResidue={setResidue}
+        variants={variants}
+        selectedVariant={selectedVariant}
+        setVariant={setVariant}
+      />
+      <View className="space-y-6">
+        <QuantityInput weight={weight} setWeight={setWeight} />
+        <ResidueConditionSelector
+          selectedCondition={selectedCondition}
+          setSelectedCondition={setCondition}
+        />
+        <PackageAvailableSelector
+          selectedPackage={selectedPackage}
+          setSelectedPackage={setPackage}
+        />
+        <TakeResiduePhoto photo={photo || null} setPhoto={setPhoto} />
+      </View>
+    </View>
+  );
+};
+export default SingleResidueSelector;

--- a/components/custom/WasteManagementInterface/SelectableResidueIcons/SingleResidueSelector/components/SingleResidueAndVariantSection/SingleResidueAndVariantsSection.tsx
+++ b/components/custom/WasteManagementInterface/SelectableResidueIcons/SingleResidueSelector/components/SingleResidueAndVariantSection/SingleResidueAndVariantsSection.tsx
@@ -1,0 +1,129 @@
+import React from "react";
+import { View, TouchableOpacity, Text } from "react-native";
+import Animated, { FadeIn, FadeOut, Layout } from "react-native-reanimated";
+import { RESIDUE_CARDS } from "@/components/custom/WasteManagementInterface/utils/enum";
+import {
+  Residue,
+  ResidueVariant,
+} from "@/components/custom/WasteManagementInterface/types";
+import { Card } from "@/components/ui/card";
+import { Image } from "@/components/ui/image";
+
+type SingleResidueAndVariantsSectionProps = {
+  selectedResidue: Residue | null;
+  variants: ResidueVariant[];
+  setResidue: (residue: Residue | null) => void;
+  setVariant: (variant: ResidueVariant | null) => void;
+  selectedVariant: ResidueVariant | null;
+};
+const SingleResidueAndVariantsSection: React.FC<
+  SingleResidueAndVariantsSectionProps
+> = ({
+  selectedResidue,
+  setResidue,
+  variants,
+  selectedVariant,
+  setVariant,
+}) => {
+  return (
+    <>
+      <Text className="mt-2 mb-2 text-base font-bold text-orange-600">
+        Escolha Seu Resíduo
+      </Text>
+      {/* Seleção de resíduo */}
+      {!selectedResidue && (
+        <Animated.View
+          entering={FadeIn.duration(200)}
+          exiting={FadeOut.duration(200)}
+          layout={Layout.springify()}
+          style={{ flexDirection: "row", flexWrap: "wrap", gap: 8 }}
+        >
+          {RESIDUE_CARDS.map((card) => (
+            <TouchableOpacity
+              key={card.id}
+              onPress={() => setResidue(card)}
+              style={{ marginBottom: 8, flexBasis: "48%" }}
+            >
+              <Card className="flex flex-row items-center rounded-sm  w-full bg-orange-100 shadow ">
+                <Image
+                  source={{ uri: card.image }}
+                  size="xs"
+                  alt={`Imagem de ${card.alt}`}
+                  className="h-12"
+                />
+                <View className="mx-auto">
+                  <Text className="text-orange-600 font-bold">{card.name}</Text>
+                </View>
+              </Card>
+            </TouchableOpacity>
+          ))}
+        </Animated.View>
+      )}
+
+      {/* Tela de variantes do resíduo selecionado */}
+      {selectedResidue && (
+        <Animated.View
+          entering={FadeIn.duration(200)}
+          exiting={FadeOut.duration(200)}
+          layout={Layout.springify()}
+        >
+          <TouchableOpacity onPress={() => setResidue(null)}>
+            <View className="flex flex-row">
+              <View className="-mt-1 mr-1">
+                <Text style={{ color: "#f97316", marginBottom: 8 }}>←</Text>
+              </View>
+              <View>
+                <Text style={{ color: "#f97316", marginBottom: 8 }}>
+                  Voltar
+                </Text>
+              </View>
+            </View>
+          </TouchableOpacity>
+
+          <Card className="flex flex-row items-center border border-orange-500 w-full rounded-sm">
+            <View className=" mx-auto">
+              <Text className="font-bold text-orange-500">
+                {selectedResidue.name}
+              </Text>
+            </View>
+          </Card>
+
+          <Card
+            style={{
+              borderColor: "#f97316",
+              backgroundColor: "#ffedd5",
+              padding: 10,
+              borderTopLeftRadius: 0,
+              borderTopRightRadius: 0,
+            }}
+          >
+            {variants.length > 0 && (
+              <View className="mt-2">
+                {variants.map((variant, idx) => (
+                  <TouchableOpacity
+                    key={idx}
+                    onPress={() => setVariant(variant)}
+                    className={`p-3 mb-2 shadow rounded-sm bg-white ${
+                      selectedVariant?.label === variant.label
+                        ? "border border-orange-500 "
+                        : "border-gray-300"
+                    }`}
+                  >
+                    <Text className="text-base font-medium">
+                      {variant.label}
+                    </Text>
+                    <Text className="text-xs text-gray-500">
+                      R$ {variant.pricePerKg}/kg • Mín: {variant.minWeightKg}
+                      kg
+                    </Text>
+                  </TouchableOpacity>
+                ))}
+              </View>
+            )}
+          </Card>
+        </Animated.View>
+      )}
+    </>
+  );
+};
+export default SingleResidueAndVariantsSection;

--- a/components/custom/WasteManagementInterface/SelectableResidueIcons/SingleResidueSelector/components/SingleResidueAndVariantSection/index.ts
+++ b/components/custom/WasteManagementInterface/SelectableResidueIcons/SingleResidueSelector/components/SingleResidueAndVariantSection/index.ts
@@ -1,0 +1,1 @@
+export { default as SingleResidueAndVariantsSection } from "./SingleResidueAndVariantsSection";

--- a/components/custom/WasteManagementInterface/SelectableResidueIcons/SingleResidueSelector/index.ts
+++ b/components/custom/WasteManagementInterface/SelectableResidueIcons/SingleResidueSelector/index.ts
@@ -1,0 +1,1 @@
+export { default as SingleResidueSelector } from "./SingleResidueSelector";

--- a/components/custom/WasteManagementInterface/WasteManagementHeadingSection/WasteManagementHeadingSection.tsx
+++ b/components/custom/WasteManagementInterface/WasteManagementHeadingSection/WasteManagementHeadingSection.tsx
@@ -1,0 +1,15 @@
+import React from "react";
+import { View, Text } from "react-native";
+import { WasteManagementHeadingSectionProps } from "../types";
+
+const WasteManagementHeadingSection: React.FC<
+  WasteManagementHeadingSectionProps
+> = ({ title, description }) => {
+  return (
+    <View className="mb-4">
+      <Text className="text-orange-600 font-bold text-base">{title}</Text>
+      <Text className="mt-2 text-xs">{description}</Text>
+    </View>
+  );
+};
+export default WasteManagementHeadingSection;

--- a/components/custom/WasteManagementInterface/WasteManagementHeadingSection/index.ts
+++ b/components/custom/WasteManagementInterface/WasteManagementHeadingSection/index.ts
@@ -1,0 +1,1 @@
+export { default as WasteManagementHeadingSection } from "./WasteManagementHeadingSection";

--- a/components/custom/WasteManagementInterface/WasteManagementInterface.tsx
+++ b/components/custom/WasteManagementInterface/WasteManagementInterface.tsx
@@ -42,7 +42,7 @@ export const WasteManagementInterface: React.FC<
   } = useResidue();
   const { authState } = useAuth();
 
-  const { priceTable } = usePriceTable(authState?.token ?? "");
+  const { priceTable } = usePriceTable(authState?.token ?? "", "sp");
 
   const variants: ResidueVariant[] =
     selectedResidue &&

--- a/components/custom/WasteManagementInterface/WasteManagementInterface.tsx
+++ b/components/custom/WasteManagementInterface/WasteManagementInterface.tsx
@@ -1,21 +1,9 @@
-import React, { useEffect, useState } from "react";
-import { View } from "react-native";
-import { Card } from "@/components/ui/card";
-import { Heading } from "@/components/ui/heading";
-import { Text } from "@/components/ui/text";
+import React from "react";
 import { SelectableResidueIcons } from "./SelectableResidueIcons";
-import { QuantityInput } from "./QuantityInput";
-import { ResidueConditionSelector } from "./ResidueConditionSelector";
-import { PackageAvailableSelector } from "./PackageAvailableSelector";
 import { AvailableDate } from "./AvailableDate";
 import { ScheduleHour } from "./ScheduleHour";
-import { TakeResiduePhoto } from "./TakeResiduePhoto";
 import { FormControl } from "@/components/ui/form-control";
 import { useResidue } from "@/hooks/useResidue";
-import { ResidueVariant } from "./types";
-import { ResidueVariantSelector } from "./ResidueVariantSelector";
-import { useAuth } from "@/context/AuthContext";
-import { usePriceTable } from "@/hooks/usePriceTable";
 
 interface WasteManagementInterfaceProps {}
 
@@ -39,59 +27,35 @@ export const WasteManagementInterface: React.FC<
     setDate,
     setHour,
     setPhoto,
+    setResidues,
+    getResiduesAsArray,
   } = useResidue();
-  const { authState } = useAuth();
-
-  const { priceTable } = usePriceTable(authState?.token ?? "", "sp");
-
-  const variants: ResidueVariant[] =
-    selectedResidue &&
-    selectedResidue.apiName &&
-    Array.isArray(priceTable?.[selectedResidue.apiName])
-      ? (priceTable[selectedResidue.apiName] as unknown as ResidueVariant[])
-      : [];
 
   return (
-    <Card className="border border-zinc-300">
-      <View className="mb-6">
-        <Heading size="xs">Detalhes do Resíduo para Descarte</Heading>
-        <Text size="xs" className="mt-2">
-          Selecione o tipo de resíduo e forneça as informações adicionais
-        </Text>
-      </View>
-
-      <FormControl className="space-y-6">
-        <SelectableResidueIcons
-          selectedResidue={selectedResidue}
-          setResidue={setResidue}
-          selectedVariant={selectedVariant}
-          setVariant={setVariant}
-        />
-        {variants.length > 0 && (
-          <ResidueVariantSelector
-            variants={variants}
-            selectedVariant={selectedVariant}
-            setSelectedVariant={setVariant}
-          />
-        )}
-        <QuantityInput weight={weight} setWeight={setWeight} />
-        <ResidueConditionSelector
-          selectedCondition={selectedCondition}
-          setSelectedCondition={setCondition}
-        />
-        <PackageAvailableSelector
-          selectedPackage={selectedPackage}
-          setSelectedPackage={setPackage}
-        />
-        <AvailableDate selectedDate={selectedDate} setSelectedDate={setDate} />
-        <ScheduleHour
-          selectedHour={selectedHour}
-          selectedDate={selectedDate}
-          setSelectedHour={setHour}
-        />
-        <TakeResiduePhoto photo={photo || null} setPhoto={setPhoto} />
-      </FormControl>
-    </Card>
+    <FormControl className="space-y-6 border-l rounded-md p-4 bg-white border-orange-300 shadow">
+      <SelectableResidueIcons
+        photo={photo}
+        setPhoto={setPhoto}
+        weight={weight}
+        setWeight={setWeight}
+        selectedResidue={selectedResidue}
+        selectedCondition={selectedCondition}
+        selectedPackage={selectedPackage}
+        setCondition={setCondition}
+        setPackage={setPackage}
+        setResidue={setResidue}
+        setResidues={setResidues}
+        selectedVariant={selectedVariant}
+        setVariant={setVariant}
+        getResiduesAsArray={getResiduesAsArray}
+      />
+      <AvailableDate selectedDate={selectedDate} setSelectedDate={setDate} />
+      <ScheduleHour
+        selectedHour={selectedHour}
+        selectedDate={selectedDate}
+        setSelectedHour={setHour}
+      />
+    </FormControl>
   );
 };
 export default WasteManagementInterface;

--- a/components/custom/WasteManagementInterface/WasteManagementInterface.tsx
+++ b/components/custom/WasteManagementInterface/WasteManagementInterface.tsx
@@ -5,11 +5,13 @@ import { ScheduleHour } from "./ScheduleHour";
 import { FormControl } from "@/components/ui/form-control";
 import { useResidue } from "@/hooks/useResidue";
 
-interface WasteManagementInterfaceProps {}
+interface WasteManagementInterfaceProps {
+  isReturnToMultipleResidues?: boolean;
+}
 
 export const WasteManagementInterface: React.FC<
   WasteManagementInterfaceProps
-> = ({}) => {
+> = ({ isReturnToMultipleResidues }) => {
   const {
     selectedResidue,
     selectedVariant,
@@ -48,6 +50,7 @@ export const WasteManagementInterface: React.FC<
         selectedVariant={selectedVariant}
         setVariant={setVariant}
         getResiduesAsArray={getResiduesAsArray}
+        isMultipleResidues={isReturnToMultipleResidues}
       />
       <AvailableDate selectedDate={selectedDate} setSelectedDate={setDate} />
       <ScheduleHour

--- a/components/custom/WasteManagementInterface/WasteManagementInterface.tsx
+++ b/components/custom/WasteManagementInterface/WasteManagementInterface.tsx
@@ -15,6 +15,7 @@ import { useResidue } from "@/hooks/useResidue";
 import { ResidueVariant } from "./types";
 import { ResidueVariantSelector } from "./ResidueVariantSelector";
 import { useAuth } from "@/context/AuthContext";
+import { usePriceTable } from "@/hooks/usePriceTable";
 
 interface WasteManagementInterfaceProps {}
 
@@ -23,6 +24,7 @@ export const WasteManagementInterface: React.FC<
 > = ({}) => {
   const {
     selectedResidue,
+    selectedVariant,
     weight,
     selectedCondition,
     selectedPackage,
@@ -30,6 +32,7 @@ export const WasteManagementInterface: React.FC<
     selectedHour,
     photo,
     setResidue,
+    setVariant,
     setWeight,
     setCondition,
     setPackage,
@@ -39,38 +42,13 @@ export const WasteManagementInterface: React.FC<
   } = useResidue();
   const { authState } = useAuth();
 
-  const [selectedVariant, setSelectedVariant] = useState<ResidueVariant | null>(
-    null
-  );
-  const [priceTable, setPriceTable] = useState<
-    Record<string, ResidueVariant[]>
-  >({});
-
-  useEffect(() => {
-    const fetchPriceTable = async () => {
-      try {
-        const res = await fetch(
-          "http://192.168.96.2:5000/api/price-tables/sp",
-          {
-            headers: { Authorization: `Bearer ${authState?.token}` },
-          }
-        );
-        const json = await res.json();
-        setPriceTable(json);
-      } catch (err) {
-        console.warn(
-          "[WasteManagementInterface] Erro ao buscar tabela de preços:",
-          err
-        );
-      }
-    };
-
-    fetchPriceTable();
-  }, []);
+  const { priceTable } = usePriceTable(authState?.token ?? "");
 
   const variants: ResidueVariant[] =
-    selectedResidue && selectedResidue.apiName
-      ? priceTable[selectedResidue.apiName] || []
+    selectedResidue &&
+    selectedResidue.apiName &&
+    Array.isArray(priceTable?.[selectedResidue.apiName])
+      ? (priceTable[selectedResidue.apiName] as unknown as ResidueVariant[])
       : [];
 
   return (
@@ -85,15 +63,15 @@ export const WasteManagementInterface: React.FC<
       <FormControl className="space-y-6">
         <SelectableResidueIcons
           selectedResidue={selectedResidue}
-          setSelectedResidue={setResidue}
+          setResidue={setResidue}
           selectedVariant={selectedVariant}
-          setSelectedVariant={setSelectedVariant}
+          setVariant={setVariant}
         />
         {variants.length > 0 && (
           <ResidueVariantSelector
             variants={variants}
             selectedVariant={selectedVariant}
-            setSelectedVariant={setSelectedVariant}
+            setSelectedVariant={setVariant}
           />
         )}
         <QuantityInput weight={weight} setWeight={setWeight} />

--- a/components/custom/WasteManagementInterface/types/index.ts
+++ b/components/custom/WasteManagementInterface/types/index.ts
@@ -77,7 +77,7 @@ type TakeResiduePhotoProps = {
 
 type SavedResiduesSectionProps = {
   residues: Residue[] | undefined;
-  handleRemove: (name: string) => void;
+  handleRemove: (variantLabel: string | undefined) => void;
   calculatePrice: (variant: ResidueVariant | null, weight: string) => string;
 };
 
@@ -93,6 +93,7 @@ type ResidueAndVariantsSelectorProps = {
   setCondition: (condition: string) => void;
   setResidue: (residue: Residue | null) => void;
   setResidues?: (residues: Residue[]) => void;
+  handleSave?: () => void;
   setWeight: (w: string) => void;
   setPhoto: (photo: string | null) => void;
   setVariant: (variant: ResidueVariant | null) => void;

--- a/components/custom/WasteManagementInterface/types/index.ts
+++ b/components/custom/WasteManagementInterface/types/index.ts
@@ -11,6 +11,7 @@ type PackageAvailableSelectorProps = {
 type QuantityInputProps = {
   weight: string;
   setWeight: (value: string) => void;
+  inputBackgroundColor?: string; // opcional, para personalização
 };
 
 type ResidueVariant = {
@@ -30,18 +31,32 @@ type Residue = {
   apiName: string;
   image: string;
   alt: string;
+  photo?: string | null; // <-- opcional, pode ser preenchido pelo usuário
   weight?: number;
+  condition?: string;
+  pkg?: string;
   _id?: string;
 
   // Campos calculados (opcionais, preenchidos pelo backend)
+  variant?: ResidueVariant | null; // <-- opcional, pode ser preenchido pelo usuário
   variants?: ResidueVariant[]; // <-- novo
 };
 
 type SelectableResidueIconsProps = {
+  photo: string | null;
   selectedResidue: Residue | null;
-  setSelectedResidue: (residue: Residue) => void;
-  selectedVariant?: ResidueVariant | null;
-  setSelectedVariant?: (variant: ResidueVariant | null) => void;
+  weight: string;
+  selectedCondition: string;
+  selectedPackage: string;
+  selectedVariant: ResidueVariant | null;
+  setPhoto: (photo: string | null) => void;
+  setPackage: (pkg: string) => void;
+  setCondition: (condition: string) => void;
+  setWeight: (w: string) => void;
+  setResidue: (residue: Residue | null) => void;
+  setVariant: (variant: ResidueVariant | null) => void;
+  getResiduesAsArray: () => Residue[];
+  setResidues: (residues: Residue[]) => void;
 };
 
 type AvailableDateProps = {
@@ -60,6 +75,34 @@ type TakeResiduePhotoProps = {
   setPhoto: (photo: string) => void;
 };
 
+type SavedResiduesSectionProps = {
+  residues: Residue[] | undefined;
+  handleRemove: (name: string) => void;
+  calculatePrice: (variant: ResidueVariant | null, weight: string) => string;
+};
+
+type ResidueAndVariantsSelectorProps = {
+  photo: string | null;
+  variants: ResidueVariant[];
+  weight: string;
+  selectedCondition: string;
+  selectedPackage: string;
+  selectedVariant: ResidueVariant | null;
+  selectedResidue: Residue | null;
+  setPackage: (pkg: string) => void;
+  setCondition: (condition: string) => void;
+  setResidue: (residue: Residue | null) => void;
+  setResidues?: (residues: Residue[]) => void;
+  setWeight: (w: string) => void;
+  setPhoto: (photo: string | null) => void;
+  setVariant: (variant: ResidueVariant | null) => void;
+};
+
+type WasteManagementHeadingSectionProps = {
+  title: string;
+  description: string;
+};
+
 export {
   TakeResiduePhotoProps,
   ScheduleHourProps,
@@ -71,4 +114,7 @@ export {
   SelectableResidueIconsProps,
   ResidueVariant,
   ResidueVariantsResponse,
+  SavedResiduesSectionProps,
+  ResidueAndVariantsSelectorProps,
+  WasteManagementHeadingSectionProps,
 };

--- a/components/custom/WasteManagementInterface/types/index.ts
+++ b/components/custom/WasteManagementInterface/types/index.ts
@@ -49,6 +49,7 @@ type SelectableResidueIconsProps = {
   selectedCondition: string;
   selectedPackage: string;
   selectedVariant: ResidueVariant | null;
+  isMultipleResidues?: boolean;
   setPhoto: (photo: string | null) => void;
   setPackage: (pkg: string) => void;
   setCondition: (condition: string) => void;

--- a/components/custom/WasteManagementInterface/types/index.ts
+++ b/components/custom/WasteManagementInterface/types/index.ts
@@ -13,18 +13,35 @@ type QuantityInputProps = {
   setWeight: (value: string) => void;
 };
 
+type ResidueVariant = {
+  label: string;
+  pricePerKg: number;
+  minWeightKg: number;
+  commission30Percent: number;
+};
+
+type ResidueVariantsResponse = {
+  variants: ResidueVariant[];
+};
+
 type Residue = {
   id: string;
   name: string;
+  apiName: string;
   image: string;
   alt: string;
   weight?: number;
   _id?: string;
+
+  // Campos calculados (opcionais, preenchidos pelo backend)
+  variants?: ResidueVariant[]; // <-- novo
 };
 
 type SelectableResidueIconsProps = {
   selectedResidue: Residue | null;
   setSelectedResidue: (residue: Residue) => void;
+  selectedVariant?: ResidueVariant | null;
+  setSelectedVariant?: (variant: ResidueVariant | null) => void;
 };
 
 type AvailableDateProps = {
@@ -52,4 +69,6 @@ export {
   QuantityInputProps,
   Residue,
   SelectableResidueIconsProps,
+  ResidueVariant,
+  ResidueVariantsResponse,
 };

--- a/components/custom/WasteManagementInterface/utils/enum.ts
+++ b/components/custom/WasteManagementInterface/utils/enum.ts
@@ -3,37 +3,43 @@ const PACKAGE_OPTIONS = ["Caixa de Papelão", "Saco de Lixo", "Solto"];
 const RESIDUE_CARDS = [
   {
     id: "1",
-    name: "Papel",
+    name: "Papel", // Nome exibido para o usuário
+    apiName: "Paper", // Nome esperado pela API
     image: "https://i.ibb.co/k25g5Lpv/paper.png",
     alt: "Papel",
   },
   {
     id: "2",
     name: "Plástico",
+    apiName: "Plastic",
     image: "https://i.ibb.co/qMX0rPkM/plastic.png",
     alt: "Plástico",
   },
   {
     id: "3",
     name: "Vidro",
+    apiName: "Glass",
     image: "https://i.ibb.co/GfM37wgP/glass.png",
     alt: "Vidro",
   },
   {
     id: "4",
     name: "Eletrônico",
+    apiName: "Electronic",
     image: "https://i.ibb.co/tTJGbF1M/electronic.png",
-    alt: "Vidro",
+    alt: "Eletrônico",
   },
   {
     id: "5",
-    name: "Orgânico",
+    name: "Orgânico",
+    apiName: "Organic",
     image: "https://i.ibb.co/tj5g2mm/organic.png",
-    alt: "Orgânico",
+    alt: "Orgânico",
   },
   {
     id: "6",
     name: "Metal",
+    apiName: "Metal",
     image: "https://i.ibb.co/nN0kbw0J/metal.png",
     alt: "Metal",
   },

--- a/components/types/index.ts
+++ b/components/types/index.ts
@@ -1,0 +1,51 @@
+import { User } from "@/types";
+import { ReactNode } from "react";
+
+interface GearButtonProps {
+  setShowActions: (showActions: boolean) => void;
+  showActions: boolean;
+  isProducesWaste: boolean;
+  isCollectsWaste: boolean;
+}
+
+interface InterfaceSwitchProps {
+  rightLabel: string;
+  leftLabel: string;
+  rightComponent: ReactNode;
+  leftComponent: ReactNode;
+  value: boolean; // Controlled value
+  onToggleChange?: (value: boolean) => void;
+}
+
+interface BackToHomeButtonProps {
+  user: User | null;
+}
+
+interface ResidueModalFlowProps {
+  visible: boolean;
+  onClose: () => void;
+}
+
+type RegionPriceTableProps = {
+  token: string | undefined | null;
+  region: string;
+};
+
+interface UserInterfaceProps {
+  user: User;
+  onLogout: (() => Promise<any>) | undefined;
+}
+
+type UserTypePickerProps = {
+  onSelect: (userType: "COLLECTS_WASTE" | "PRODUCES_WASTE") => void;
+};
+
+export {
+  UserTypePickerProps,
+  RegionPriceTableProps,
+  ResidueModalFlowProps,
+  GearButtonProps,
+  BackToHomeButtonProps,
+  InterfaceSwitchProps,
+  UserInterfaceProps,
+};

--- a/context/CollectFlowContext.tsx
+++ b/context/CollectFlowContext.tsx
@@ -1,5 +1,6 @@
 import React, { createContext, useContext, useEffect, useState } from "react";
-import { CollectFlowState, ResiduePayload, ResidueWithDetails } from "./types";
+import { CollectFlowState } from "./types";
+import { Residue } from "@/components/custom/WasteManagementInterface/types";
 
 const CollectFlowContext = createContext<CollectFlowState | undefined>(
   undefined
@@ -137,9 +138,9 @@ export const CollectFlowProvider: React.FC<{ children: React.ReactNode }> = ({
     };
   };
 
-  const getResiduesPayloadArray = (): ResiduePayload[] => {
+  const getResiduesPayloadArray = (residues: any) => {
     return (
-      state.selectedResidues?.map((r) => ({
+      residues?.map((r: Residue) => ({
         name: r.name,
         apiName: r.apiName,
         variant: r.variant?.label || null,
@@ -160,7 +161,7 @@ export const CollectFlowProvider: React.FC<{ children: React.ReactNode }> = ({
         setCollectFlowData,
         resetCollectFlow,
         getResiduePayload: () => getResiduePayload(),
-        getResiduesPayloadArray: () => getResiduesPayloadArray(),
+        getResiduesPayloadArray: () => getResiduesPayloadArray(state.residues),
         resetAddressData, // 👈 exposed here
       }}
     >

--- a/context/CollectFlowContext.tsx
+++ b/context/CollectFlowContext.tsx
@@ -1,5 +1,5 @@
 import React, { createContext, useContext, useEffect, useState } from "react";
-import { CollectFlowState } from "./types";
+import { CollectFlowState, ResiduePayload, ResidueWithDetails } from "./types";
 
 const CollectFlowContext = createContext<CollectFlowState | undefined>(
   undefined
@@ -14,9 +14,12 @@ export const CollectFlowProvider: React.FC<{ children: React.ReactNode }> = ({
       | "setCollectFlowData"
       | "resetCollectFlow"
       | "getResiduePayload"
+      | "getResiduesPayloadArray"
       | "resetAddressData"
     >
   >({
+    selectedResidues: [], // Initialize selectedResidues as an empty array
+    residues: [], // Initialize residues as null
     selectedResidue: null,
     selectedVariant: null,
     weight: "",
@@ -49,6 +52,8 @@ export const CollectFlowProvider: React.FC<{ children: React.ReactNode }> = ({
 
   const resetCollectFlow = () => {
     setState({
+      residues: [],
+      selectedResidues: [], // Initialize selectedResidues as an empty array
       selectedResidue: null,
       selectedVariant: null,
       weight: "",
@@ -64,6 +69,8 @@ export const CollectFlowProvider: React.FC<{ children: React.ReactNode }> = ({
       status: "",
       isSigned: false,
       signedBy: null,
+      latitude: undefined, // or null
+      longitude: undefined,
 
       city: "",
       neighborhood: "",
@@ -130,6 +137,20 @@ export const CollectFlowProvider: React.FC<{ children: React.ReactNode }> = ({
     };
   };
 
+  const getResiduesPayloadArray = (): ResiduePayload[] => {
+    return (
+      state.selectedResidues?.map((r) => ({
+        name: r.name,
+        apiName: r.apiName,
+        variant: r.variant?.label || null,
+        weight: r.weight,
+        condition: r.condition, // ensure these fields exist on ResidueWithDetails
+        pkg: r.pkg,
+        photo: r.photo || null,
+      })) ?? []
+    );
+  };
+
   console.log("CollectFlowProvider state:", state);
 
   return (
@@ -139,6 +160,7 @@ export const CollectFlowProvider: React.FC<{ children: React.ReactNode }> = ({
         setCollectFlowData,
         resetCollectFlow,
         getResiduePayload: () => getResiduePayload(),
+        getResiduesPayloadArray: () => getResiduesPayloadArray(),
         resetAddressData, // 👈 exposed here
       }}
     >

--- a/context/CollectFlowContext.tsx
+++ b/context/CollectFlowContext.tsx
@@ -122,7 +122,7 @@ export const CollectFlowProvider: React.FC<{ children: React.ReactNode }> = ({
     return {
       name: state.selectedResidue.name,
       apiName: state.selectedResidue.apiName,
-      variant: state.selectedVariant ? state.selectedVariant.label : null,
+      variant: state.selectedVariant ? state.selectedVariant : null,
       weight: state.weight,
       condition: state.selectedCondition,
       pkg: state.selectedPackage,

--- a/context/CollectFlowContext.tsx
+++ b/context/CollectFlowContext.tsx
@@ -122,7 +122,7 @@ export const CollectFlowProvider: React.FC<{ children: React.ReactNode }> = ({
     return {
       name: state.selectedResidue.name,
       apiName: state.selectedResidue.apiName,
-      variant: state.selectedVariant ? state.selectedVariant : null,
+      variant: state.selectedVariant ? state.selectedVariant.label : null,
       weight: state.weight,
       condition: state.selectedCondition,
       pkg: state.selectedPackage,

--- a/context/CollectFlowContext.tsx
+++ b/context/CollectFlowContext.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useContext, useState } from "react";
+import React, { createContext, useContext, useEffect, useState } from "react";
 import { CollectFlowState } from "./types";
 
 const CollectFlowContext = createContext<CollectFlowState | undefined>(
@@ -18,7 +18,11 @@ export const CollectFlowProvider: React.FC<{ children: React.ReactNode }> = ({
     >
   >({
     selectedResidue: null,
+    selectedVariant: null,
     weight: "",
+    pricePerKg: null,
+    minWeightKg: null,
+    estimatedValue: null,
     selectedCondition: "Limpo",
     selectedPackage: "Caixa de Papelão",
     selectedDate: null,
@@ -46,7 +50,11 @@ export const CollectFlowProvider: React.FC<{ children: React.ReactNode }> = ({
   const resetCollectFlow = () => {
     setState({
       selectedResidue: null,
+      selectedVariant: null,
       weight: "",
+      pricePerKg: null,
+      minWeightKg: null,
+      estimatedValue: null,
       selectedCondition: "Limpo",
       selectedPackage: "Caixa de Papelão",
       selectedDate: null,
@@ -83,11 +91,37 @@ export const CollectFlowProvider: React.FC<{ children: React.ReactNode }> = ({
     }));
   };
 
+  useEffect(() => {
+    if (state.selectedVariant && state.weight) {
+      const weightNum = parseFloat(state.weight);
+      if (!isNaN(weightNum)) {
+        const { pricePerKg, minWeightKg } = state.selectedVariant;
+        const estimatedValue =
+          weightNum >= minWeightKg ? weightNum * pricePerKg : 0;
+
+        setState((prev) => ({
+          ...prev,
+          pricePerKg,
+          minWeightKg,
+          estimatedValue: parseFloat(estimatedValue.toFixed(2)),
+        }));
+      }
+    } else {
+      setState((prev) => ({
+        ...prev,
+        pricePerKg: null,
+        minWeightKg: null,
+        estimatedValue: null,
+      }));
+    }
+  }, [state.selectedVariant, state.weight]);
+
   const getResiduePayload = () => {
     if (!state.selectedResidue) return null;
 
     return {
       name: state.selectedResidue.name,
+      variant: state.selectedVariant ? state.selectedVariant.label : null,
       weight: state.weight,
       condition: state.selectedCondition,
       pkg: state.selectedPackage,
@@ -103,7 +137,7 @@ export const CollectFlowProvider: React.FC<{ children: React.ReactNode }> = ({
         ...state,
         setCollectFlowData,
         resetCollectFlow,
-        getResiduePayload,
+        getResiduePayload: () => getResiduePayload(),
         resetAddressData, // 👈 exposed here
       }}
     >

--- a/context/CollectFlowContext.tsx
+++ b/context/CollectFlowContext.tsx
@@ -121,6 +121,7 @@ export const CollectFlowProvider: React.FC<{ children: React.ReactNode }> = ({
 
     return {
       name: state.selectedResidue.name,
+      apiName: state.selectedResidue.apiName,
       variant: state.selectedVariant ? state.selectedVariant.label : null,
       weight: state.weight,
       condition: state.selectedCondition,

--- a/context/UserContext.tsx
+++ b/context/UserContext.tsx
@@ -1,5 +1,5 @@
 import React, { createContext, useContext, useEffect, useState } from "react";
-import { User } from "@/app/Home";
+import { User } from "@/types";
 import { useAuth } from "./AuthContext";
 import axios from "axios";
 import Constants from "expo-constants";

--- a/context/UserContext.tsx
+++ b/context/UserContext.tsx
@@ -5,18 +5,9 @@ import axios from "axios";
 import Constants from "expo-constants";
 import { router } from "expo-router";
 import * as SecureStore from "expo-secure-store";
+import { UserContextProps } from "./types";
 
 const { API_URL, TOKEN_KEY } = Constants.expoConfig?.extra || {};
-
-interface UserContextProps {
-  user: User | null;
-  loading: boolean;
-  refreshUser: () => Promise<void>;
-  updateUser: (data: Partial<User>) => Promise<void>;
-  deleteUser: () => Promise<void>;
-  changePassword: (oldPassword: string, newPassword: string) => Promise<void>;
-  loadUser: () => Promise<void>;
-}
 
 const UserContext = createContext<UserContextProps>({
   user: null,

--- a/context/types/index.ts
+++ b/context/types/index.ts
@@ -83,7 +83,7 @@ interface CollectFlowState {
     condition: string;
     pkg: string;
     photo: string | null;
-    variant: ResidueVariant | null;
+    variant: string | null;
   } | null;
 }
 

--- a/context/types/index.ts
+++ b/context/types/index.ts
@@ -45,8 +45,30 @@ interface AuthProps {
   >;
 }
 
+type ResidueWithDetails = {
+  name: string;
+  apiName: string;
+  variant: ResidueVariant | null;
+  weight: string;
+  condition: string;
+  pkg: string;
+  photo: string | null;
+};
+
+type ResiduePayload = {
+  name: string;
+  apiName: string;
+  variant: string | null; // variant label
+  weight: string;
+  condition: string;
+  pkg: string;
+  photo: string | null;
+};
+
 interface CollectFlowState {
+  residues?: Residue[];
   selectedResidue: Residue | null;
+  selectedResidues: ResidueWithDetails[] | null;
   selectedVariant: ResidueVariant | null;
   pricePerKg: number | null;
   minWeightKg: number | null;
@@ -77,14 +99,8 @@ interface CollectFlowState {
   setCollectFlowData: (data: Partial<CollectFlowState>) => void;
   resetCollectFlow: () => void;
   resetAddressData: () => void;
-  getResiduePayload: () => {
-    name: string;
-    weight: string;
-    condition: string;
-    pkg: string;
-    photo: string | null;
-    variant: string | null;
-  } | null;
+  getResiduePayload: () => ResiduePayload | null;
+  getResiduesPayloadArray: () => ResiduePayload[];
 }
 
 interface WasteProducerContextProps {
@@ -108,5 +124,7 @@ export {
   CollectFlowState,
   WasteProducerContextProps,
   GoogleProfile,
+  ResidueWithDetails,
+  ResiduePayload,
   // Add other types here as needed
 };

--- a/context/types/index.ts
+++ b/context/types/index.ts
@@ -119,8 +119,19 @@ interface GoogleProfile {
   photo?: string | null;
 }
 
+interface UserContextProps {
+  user: User | null;
+  loading: boolean;
+  refreshUser: () => Promise<void>;
+  updateUser: (data: Partial<User>) => Promise<void>;
+  deleteUser: () => Promise<void>;
+  changePassword: (oldPassword: string, newPassword: string) => Promise<void>;
+  loadUser: () => Promise<void>;
+}
+
 export {
   AuthProps,
+  UserContextProps,
   CollectFlowState,
   WasteProducerContextProps,
   GoogleProfile,

--- a/context/types/index.ts
+++ b/context/types/index.ts
@@ -1,4 +1,4 @@
-import { User } from "@/app/Home";
+import { User } from "@/types";
 import { Address } from "@/components/custom/AddressInterface/types";
 import {
   Residue,

--- a/context/types/index.ts
+++ b/context/types/index.ts
@@ -83,6 +83,7 @@ interface CollectFlowState {
     condition: string;
     pkg: string;
     photo: string | null;
+    variant: ResidueVariant | null;
   } | null;
 }
 

--- a/context/types/index.ts
+++ b/context/types/index.ts
@@ -1,6 +1,9 @@
 import { User } from "@/app/Home";
 import { Address } from "@/components/custom/AddressInterface/types";
-import { Residue } from "@/components/custom/WasteManagementInterface/types";
+import {
+  Residue,
+  ResidueVariant,
+} from "@/components/custom/WasteManagementInterface/types";
 import { AxiosResponse } from "axios";
 
 interface AuthProps {
@@ -44,6 +47,10 @@ interface AuthProps {
 
 interface CollectFlowState {
   selectedResidue: Residue | null;
+  selectedVariant: ResidueVariant | null;
+  pricePerKg: number | null;
+  minWeightKg: number | null;
+  estimatedValue: number | null;
   weight: string;
   selectedCondition: string;
   selectedPackage: string;

--- a/hooks/useCollectHookEvent.ts
+++ b/hooks/useCollectHookEvent.ts
@@ -107,6 +107,8 @@ export const useCollectEvent = () => {
       console.log("✅ Created residue:", finalResidueId);
 
       const formattedResidue = residuePayload?.name || "Coleta";
+      const formattedSingleResidueVariant =
+        residuePayload?.variant || "Sem variante";
       const shortDate = newDate.toLocaleDateString("pt-BR");
       const shortTime = newDate.toLocaleTimeString("pt-BR", {
         hour: "2-digit",
@@ -114,7 +116,7 @@ export const useCollectEvent = () => {
       });
       const userName = user?.firstName?.split(" ")[0] || "Usuário";
 
-      const dynamicEventName = `Coleta de ${formattedResidue} - ${userName}`;
+      const dynamicEventName = `Coleta de ${formattedResidue}: ${formattedSingleResidueVariant} - ${userName}`;
       const dynamicDescription = `Coleta agendada por ${
         userName || "usuário"
       } para ${street}, ${number} - ${neighborhood}, ${city}, ${state} em ${shortDate} às ${shortTime}`;

--- a/hooks/useCollectHookEvent.ts
+++ b/hooks/useCollectHookEvent.ts
@@ -116,7 +116,7 @@ export const useCollectEvent = () => {
           { residues: residuesPayloadArray },
           { headers: { Authorization: `Bearer ${token}` } }
         );
-        residueIds = batchRes.data.map((r: any) => r._id);
+        residueIds = batchRes.data.created.map((r: any) => r._id);
         const residueNames = residuesPayloadArray.map((r) => r.name).join(", ");
         dynamicEventName = `Coleta de ${residueNames} - ${userName}`;
       } else if (residuePayload) {

--- a/hooks/usePriceTable.ts
+++ b/hooks/usePriceTable.ts
@@ -18,7 +18,7 @@ type PriceTable = {
 
 const { API_URL } = Constants.expoConfig?.extra || {};
 
-export function usePriceTable(token?: string | null) {
+export function usePriceTable(token?: string | null, region?: string) {
   const [priceTable, setPriceTable] = useState<PriceTable | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<Error | null>(null);
@@ -29,12 +29,9 @@ export function usePriceTable(token?: string | null) {
     const fetchPriceTable = async () => {
       setLoading(true);
       try {
-        const res = await fetch(
-          "http://192.168.96.2:5000/api/price-tables/sp",
-          {
-            headers: { Authorization: `Bearer ${token}` },
-          }
-        );
+        const res = await fetch(`${API_URL}/price-tables/${region}`, {
+          headers: { Authorization: `Bearer ${token}` },
+        });
 
         if (!res.ok) {
           throw new Error(`HTTP ${res.status}: ${res.statusText}`);

--- a/hooks/usePriceTable.ts
+++ b/hooks/usePriceTable.ts
@@ -1,0 +1,59 @@
+import { useEffect, useState } from "react";
+import Constants from "expo-constants";
+
+type Variant = {
+  label: string;
+  pricePerKg: number;
+  minWeightKg: number;
+  commission30Percent: number;
+};
+
+type Category = {
+  variants: Variant[];
+};
+
+type PriceTable = {
+  [category: string]: Category;
+};
+
+const { API_URL } = Constants.expoConfig?.extra || {};
+
+export function usePriceTable(token?: string | null) {
+  const [priceTable, setPriceTable] = useState<PriceTable | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    if (!token) return;
+
+    const fetchPriceTable = async () => {
+      setLoading(true);
+      try {
+        const res = await fetch(
+          "http://192.168.96.2:5000/api/price-tables/sp",
+          {
+            headers: { Authorization: `Bearer ${token}` },
+          }
+        );
+
+        if (!res.ok) {
+          throw new Error(`HTTP ${res.status}: ${res.statusText}`);
+        }
+
+        const json = await res.json();
+        setPriceTable(json);
+        setError(null);
+      } catch (err: any) {
+        console.warn("[usePriceTable] Erro ao buscar tabela de preços:", err);
+        setError(err);
+        setPriceTable(null);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchPriceTable();
+  }, [token]);
+
+  return { priceTable, loading, error };
+}

--- a/hooks/useResidue.ts
+++ b/hooks/useResidue.ts
@@ -56,6 +56,21 @@ export const useResidue = () => {
     selectedHour &&
     selectedDate;
 
+  const isResiduesValid = (residues: Residue[] | undefined): boolean => {
+    if (!residues || residues.length === 0) return false;
+
+    return residues.every(
+      (r) =>
+        !!r.name &&
+        !!r.variant?.label &&
+        !!r.variant?.pricePerKg &&
+        !!r.variant?.minWeightKg &&
+        !!r.weight &&
+        !!r.condition &&
+        !!r.pkg
+    );
+  };
+
   const setResidues = (r: Residue[]) => setCollectFlowData({ residues: r });
 
   const getResiduesAsArray = (): Residue[] => residues ?? [];
@@ -82,6 +97,7 @@ export const useResidue = () => {
     setHour,
     setPhoto,
     isResidueValid,
+    isResiduesValid,
     payloadResidue: getResiduePayload(), // inclui pricePerKg, estimatedValue...
     payloadResiduesArray: getResiduesPayloadArray(),
     getResiduesAsArray, // função para obter os resíduos como array

--- a/hooks/useResidue.ts
+++ b/hooks/useResidue.ts
@@ -67,7 +67,9 @@ export const useResidue = () => {
         !!r.variant?.minWeightKg &&
         !!r.weight &&
         !!r.condition &&
-        !!r.pkg
+        !!r.pkg &&
+        !!selectedHour &&
+        !!selectedDate
     );
   };
 

--- a/hooks/useResidue.ts
+++ b/hooks/useResidue.ts
@@ -1,8 +1,12 @@
-import { Residue } from "@/components/custom/WasteManagementInterface/types";
+import {
+  Residue,
+  ResidueVariant,
+} from "@/components/custom/WasteManagementInterface/types";
 import { useCollectFlow } from "@/context/CollectFlowContext";
 
 export const useResidue = () => {
   const {
+    selectedVariant,
     selectedResidue,
     weight,
     selectedCondition,
@@ -10,25 +14,40 @@ export const useResidue = () => {
     selectedDate,
     selectedHour,
     photo,
+    pricePerKg,
+    minWeightKg,
+    estimatedValue,
     setCollectFlowData,
     getResiduePayload,
   } = useCollectFlow();
 
+  const setVariant = (variant: ResidueVariant | null) =>
+    setCollectFlowData({ selectedVariant: variant });
+
   const setResidue = (residue: Residue | null) =>
     setCollectFlowData({ selectedResidue: residue });
+
   const setWeight = (w: string) => setCollectFlowData({ weight: w });
+
   const setCondition = (condition: string) =>
     setCollectFlowData({ selectedCondition: condition });
+
   const setPackage = (pkg: string) =>
     setCollectFlowData({ selectedPackage: pkg });
+
   const setDate = (date: Date | null) =>
     setCollectFlowData({ selectedDate: date });
+
   const setHour = (hour: string | null) =>
     setCollectFlowData({ selectedHour: hour });
+
   const setPhoto = (p: string | null) => setCollectFlowData({ photo: p });
 
   const isResidueValid =
     !!selectedResidue?.name &&
+    !!selectedVariant?.label &&
+    !!selectedVariant?.pricePerKg &&
+    !!selectedVariant?.minWeightKg &&
     weight &&
     selectedCondition &&
     selectedPackage &&
@@ -36,6 +55,7 @@ export const useResidue = () => {
     selectedDate;
 
   return {
+    selectedVariant,
     selectedResidue,
     weight,
     selectedCondition,
@@ -43,6 +63,10 @@ export const useResidue = () => {
     selectedDate,
     selectedHour,
     photo,
+    pricePerKg,
+    minWeightKg,
+    estimatedValue,
+    setVariant,
     setResidue,
     setWeight,
     setCondition,
@@ -51,6 +75,6 @@ export const useResidue = () => {
     setHour,
     setPhoto,
     isResidueValid,
-    payloadResidue: getResiduePayload(), // 🔥 easy
+    payloadResidue: getResiduePayload(), // inclui pricePerKg, estimatedValue...
   };
 };

--- a/hooks/useResidue.ts
+++ b/hooks/useResidue.ts
@@ -6,6 +6,7 @@ import { useCollectFlow } from "@/context/CollectFlowContext";
 
 export const useResidue = () => {
   const {
+    residues,
     selectedVariant,
     selectedResidue,
     weight,
@@ -19,6 +20,7 @@ export const useResidue = () => {
     estimatedValue,
     setCollectFlowData,
     getResiduePayload,
+    getResiduesPayloadArray,
   } = useCollectFlow();
 
   const setVariant = (variant: ResidueVariant | null) =>
@@ -54,6 +56,10 @@ export const useResidue = () => {
     selectedHour &&
     selectedDate;
 
+  const setResidues = (r: Residue[]) => setCollectFlowData({ residues: r });
+
+  const getResiduesAsArray = (): Residue[] => residues ?? [];
+
   return {
     selectedVariant,
     selectedResidue,
@@ -66,6 +72,7 @@ export const useResidue = () => {
     pricePerKg,
     minWeightKg,
     estimatedValue,
+    setResidues, // função para definir os resíduos
     setVariant,
     setResidue,
     setWeight,
@@ -76,5 +83,7 @@ export const useResidue = () => {
     setPhoto,
     isResidueValid,
     payloadResidue: getResiduePayload(), // inclui pricePerKg, estimatedValue...
+    payloadResiduesArray: getResiduesPayloadArray(),
+    getResiduesAsArray, // função para obter os resíduos como array
   };
 };

--- a/types/index.ts
+++ b/types/index.ts
@@ -1,0 +1,13 @@
+interface User {
+  email?: string;
+  photo?: string;
+  phone?: string;
+  document?: string;
+  status?: string;
+  accountType?: string;
+  firstName: string;
+  lastName: string;
+  userType: string;
+}
+
+export { User };

--- a/types/index.ts
+++ b/types/index.ts
@@ -9,5 +9,6 @@ interface User {
   lastName: string;
   userType: string;
 }
+//CreateCollectModal
 
 export { User };


### PR DESCRIPTION
# Descrição

[Dev Build](https://expo.dev/accounts/wakenedo/projects/RecoletaNative/builds/2875b8c6-5a07-4b50-b3cb-443571551a5b)
[Preview Build](https://expo.dev/accounts/wakenedo/projects/RecoletaNative/builds/2e348ef9-fd85-41cc-bd5f-0621d3cbb225) 

Nesse PR implementamos a integração das novas funcionalidades do BE como a lógica de precificação apartir das tabelas de preço que serão adicionadas e selecionadas pelo sistema a partir da localização atual do usuário, por enquanto estamos usando apenas a tabela referente a sp como prova de conceito.  Lembrando que agora os `Resídous` contém variantes e essas variantes que tem as informações de precificação integradas do BE.

Adicionamos a capacidade dos usuários GERADORES criarem eventos de coleta com mais de um resíduo, com mínimo de 2 e máximo de 10, refatoramos o `WasteManagementInterface` em conjunto com o `SelectableResiudeIcons` incluíndo estilos iniciais seguindo as cores do `UserType`

Realizamos também um esforço para centralizar os tipos e organização do projeto.